### PR TITLE
refactor(domain): extract exponential backoff into LookupSchedule helper

### DIFF
--- a/src/Ruvarr/Abstractions/LookupSchedule.cs
+++ b/src/Ruvarr/Abstractions/LookupSchedule.cs
@@ -1,0 +1,13 @@
+namespace Ruvarr.Abstractions;
+
+internal static class LookupSchedule
+{
+    internal static DateTime ComputeNextLookup(int lookupCount) => DateTime.UtcNow.Add(lookupCount switch
+    {
+        1 => TimeSpan.FromHours(1),
+        2 => TimeSpan.FromHours(2),
+        3 => TimeSpan.FromHours(4),
+        4 => TimeSpan.FromDays(1),
+        _ => TimeSpan.FromDays(7)
+    });
+}

--- a/src/Ruvarr/Programs/Domain/RuvEpisode.cs
+++ b/src/Ruvarr/Programs/Domain/RuvEpisode.cs
@@ -123,16 +123,7 @@ internal sealed partial class RuvEpisode
         }
 
         LookupCount++;
-
-        DateTime now = DateTime.UtcNow;
-        NextLookup = LookupCount switch
-        {
-            1 => now.AddHours(1),
-            2 => now.AddHours(2),
-            3 => now.AddHours(4),
-            4 => now.AddDays(1),
-            _ => now.AddDays(7)
-        };
+        NextLookup = LookupSchedule.ComputeNextLookup(LookupCount);
     }
 
     public bool IsMatch(string value)

--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -1,4 +1,6 @@
-﻿namespace Ruvarr.Programs.Domain;
+﻿using Ruvarr.Abstractions;
+
+namespace Ruvarr.Programs.Domain;
 
 internal sealed class RuvProgram
 {
@@ -69,16 +71,7 @@ internal sealed class RuvProgram
     public void ScheduleLookup()
     {
         LookupCount++;
-
-        DateTime now = DateTime.UtcNow;
-        NextLookup = LookupCount switch
-        {
-            1 => now.AddHours(1),
-            2 => now.AddHours(2),
-            3 => now.AddHours(4),
-            4 => now.AddDays(1),
-            _ => now.AddDays(7)
-        };
+        NextLookup = LookupSchedule.ComputeNextLookup(LookupCount);
     }
 
     public bool TryAddEpisode(string id, Uri uri, string title, string description, DateTime firstRun)


### PR DESCRIPTION
Deduplicates the switch expression shared between RuvProgram.ScheduleLookup() and RuvEpisode.ScheduleLookup() into a single static LookupSchedule.ComputeNextLookup().