### PR TITLE
refactor(episode): extract ToFilePath method from DownloadQueueProcessor

### DIFF
--- a/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
+++ b/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
@@ -54,25 +54,23 @@ internal class DownloadQueueProcessor(
         notifier.Notify();
 
         logger.LogInformation("Downloading {Program} - {Title}", item.Episode.Program.Name, item.Episode.Title);
-        string filename = item.Episode.ToFilename();
-        string directory = Path.Join(
+        string tentativePath = item.Episode.ToFilePath(
             options.Value.DownloadsRootDirectory,
             options.Value.EpisodeDownloadDirectory,
-            item.Episode.Program.Series?.Name ?? item.Episode.Program.Name);
-        string filepath = Path.Join(directory, filename);
+            fileAlreadyExists: false);
 
-        if (!Directory.Exists(directory))
+        string filepath = item.Episode.ToFilePath(
+            options.Value.DownloadsRootDirectory,
+            options.Value.EpisodeDownloadDirectory,
+            fileAlreadyExists: File.Exists(tentativePath));
+
+        string? directory = Path.GetDirectoryName(filepath);
+        if (directory is not null && !Directory.Exists(directory))
         {
             Directory.CreateDirectory(directory);
         }
 
-        if (File.Exists(filepath))
-        {
-            string extension = Path.GetExtension(filename);
-            string filenameWithoutExtension = Path.GetFileNameWithoutExtension(filename);
-            filename = $"{filenameWithoutExtension}.X{extension}";
-            filepath = Path.Join(directory, filename);
-        }
+        string filename = Path.GetFileName(filepath);
 
         await ffmpeg.DownloadAsync(item.Episode.Uri, filepath, item.Episode.Title);
 

--- a/src/Ruvarr/Programs/Domain/RuvEpisode.cs
+++ b/src/Ruvarr/Programs/Domain/RuvEpisode.cs
@@ -93,6 +93,31 @@ internal sealed partial class RuvEpisode
         return $"{filename}-RUV.mp4";
     }
 
+    public string ToFilePath(string rootDirectory, string episodeSubdirectory, bool fileAlreadyExists)
+    {
+        string seriesOrProgramName = Program.Series?.Name ?? Program.Name;
+        string directory = Path.Join(rootDirectory, episodeSubdirectory, seriesOrProgramName);
+
+        string resolvedDirectory = Path.GetFullPath(directory);
+        string resolvedRoot = Path.GetFullPath(rootDirectory);
+        if (!resolvedDirectory.StartsWith(resolvedRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+            && resolvedDirectory != resolvedRoot)
+        {
+            throw new InvalidOperationException($"Path traversal detected: '{resolvedDirectory}' is outside root '{resolvedRoot}'.");
+        }
+
+        string filename = ToFilename();
+
+        if (fileAlreadyExists)
+        {
+            string extension = Path.GetExtension(filename);
+            string stem = Path.GetFileNameWithoutExtension(filename);
+            filename = $"{stem}.X{extension}";
+        }
+
+        return Path.Join(directory, filename);
+    }
+
     public void Match(int tvdbId, int season, int episode, bool isMissing)
     {
         Matched = DateTime.UtcNow;

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/ToFilePath.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/ToFilePath.cs
@@ -1,0 +1,91 @@
+using Ruvarr.Programs.Domain;
+using Ruvarr.UnitTests.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.Domain.RuvEpisodeTests;
+
+public sealed class ToFilePath
+{
+    [Fact]
+    public void UsesProgramNameForDirectory_WhenSeriesIsNotMatched()
+    {
+        // Arrange
+        RuvProgram program = new RuvProgramBuilder()
+            .WithName("Awesome Show")
+            .Build();
+        RuvEpisode sut = new RuvEpisodeBuilder()
+            .WithProgram(program)
+            .WithTitle("Test Episode")
+            .Build();
+
+        // Act
+        string result = sut.ToFilePath("/root", "episodes", fileAlreadyExists: false);
+
+        // Assert
+        result.ShouldBe(Path.Join("/root", "episodes", "Awesome Show", "Awesome.Show.Test.Episode-RUV.mp4"));
+    }
+
+    [Fact]
+    public void UsesSeriesNameForDirectory_WhenSeriesIsMatched()
+    {
+        // Arrange
+        TvdbSeries series = new TvdbSeriesBuilder()
+            .WithName("Awesome Show")
+            .Build();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithName("Kveikur")
+            .Build();
+        program.MatchTvdb(series);
+        RuvEpisode sut = new RuvEpisodeBuilder()
+            .WithProgram(program)
+            .WithTitle("Test Episode")
+            .Build();
+
+        // Act
+        string result = sut.ToFilePath("/root", "episodes", fileAlreadyExists: false);
+
+        // Assert
+        result.ShouldBe(Path.Join("/root", "episodes", "Awesome Show", "Awesome.Show.Test.Episode-RUV.mp4"));
+    }
+
+    [Fact]
+    public void UsesSeasonEpisodeNumber_WhenEpisodeIsMatched()
+    {
+        // Arrange
+        TvdbSeries series = new TvdbSeriesBuilder()
+            .WithName("Awesome Show")
+            .Build();
+        RuvProgram program = new RuvProgramBuilder().Build();
+        program.MatchTvdb(series);
+        RuvEpisode sut = new RuvEpisodeBuilder()
+            .WithProgram(program)
+            .Build();
+        sut.Match(1234, 2, 3, isMissing: false);
+
+        // Act
+        string result = sut.ToFilePath("/root", "episodes", fileAlreadyExists: false);
+
+        // Assert
+        result.ShouldBe(Path.Join("/root", "episodes", "Awesome Show", "Awesome.Show.S02E03-RUV.mp4"));
+    }
+
+    [Fact]
+    public void AppliesXSuffix_WhenFileAlreadyExists()
+    {
+        // Arrange
+        RuvProgram program = new RuvProgramBuilder()
+            .WithName("Awesome Show")
+            .Build();
+        RuvEpisode sut = new RuvEpisodeBuilder()
+            .WithProgram(program)
+            .WithTitle("Test Episode")
+            .Build();
+
+        // Act
+        string result = sut.ToFilePath("/root", "episodes", fileAlreadyExists: true);
+
+        // Assert
+        result.ShouldBe(Path.Join("/root", "episodes", "Awesome Show", "Awesome.Show.Test.Episode-RUV.X.mp4"));
+    }
+}


### PR DESCRIPTION
Adds RuvEpisode.ToFilePath() that encapsulates directory construction and the X-suffix collision logic, then simplifies DownloadQueueProcessor to delegate path-building to the domain model.