### PR TITLE
feat(programs): add filter presets to programs page

### DIFF
--- a/src/Ruvarr.Blazor/Components/App.razor
+++ b/src/Ruvarr.Blazor/Components/App.razor
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ruvarr</title>
     <base href="/" />
-    <link rel="stylesheet" href="app.css" />
+    <link rel="stylesheet" href="app.css" @@fingerprint />
 </head>
 <body>
     <Routes />

--- a/src/Ruvarr.Blazor/Components/Layout/NavMenu.razor
+++ b/src/Ruvarr.Blazor/Components/Layout/NavMenu.razor
@@ -3,11 +3,7 @@
 @implements IDisposable
 
 <nav class="nav">
-    <details class="nav-group" open="@_programsOpen">
-        <summary class="nav-link" @onclick="TogglePrograms" @onclick:preventDefault>Programs</summary>
-        <NavLink class="nav-link nav-link--nested" href="/" Match="NavLinkMatch.All">All Programs</NavLink>
-        <NavLink class="nav-link nav-link--nested" href="/unmatched-episodes">Unmatched Episodes</NavLink>
-    </details>
+    <NavLink class="nav-link" href="/" Match="NavLinkMatch.All" ActiveClass="nav-link--active">Programs</NavLink>
     <details class="nav-group" open="@_queuesOpen">
         <summary class="nav-link" @onclick="ToggleQueues" @onclick:preventDefault>Queues</summary>
         <NavLink class="nav-link nav-link--nested" href="/download-queue">Download</NavLink>
@@ -18,35 +14,26 @@
 </nav>
 
 @code {
-    private bool _programsOpen;
     private bool _queuesOpen;
 
     protected override void OnInitialized()
     {
-        _programsOpen = IsProgramRoute();
         _queuesOpen = IsQueueRoute();
         Navigation.LocationChanged += OnLocationChanged;
     }
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {
-        if (IsProgramRoute())
-            _programsOpen = true;
         if (IsQueueRoute())
             _queuesOpen = true;
         InvokeAsync(StateHasChanged);
     }
-
-    private bool IsProgramRoute() =>
-        Navigation.ToBaseRelativePath(Navigation.Uri) is "" or "unmatched-episodes";
 
     private bool IsQueueRoute() =>
         Navigation.Uri.Contains("/download-queue") ||
         Navigation.Uri.Contains("/program-refresh-queue") ||
         Navigation.Uri.Contains("/tvdb-series-lookup-queue") ||
         Navigation.Uri.Contains("/tvdb-episode-lookup-queue");
-
-    private void TogglePrograms() => _programsOpen = !_programsOpen;
 
     private void ToggleQueues() => _queuesOpen = !_queuesOpen;
 

--- a/src/Ruvarr.Blazor/Program.cs
+++ b/src/Ruvarr.Blazor/Program.cs
@@ -14,8 +14,9 @@ builder.Services.AddHttpClient<RuvApiClient>(client =>
 
 WebApplication app = builder.Build();
 
-app.UseStaticFiles();
+app.MapStaticAssets();
 app.UseAntiforgery();
-app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
 
 await app.RunAsync();

--- a/src/Ruvarr.Blazor/Programs/Programs.razor
+++ b/src/Ruvarr.Blazor/Programs/Programs.razor
@@ -1,10 +1,22 @@
 @page "/"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 @inject RuvApiClient ApiClient
+@inject NavigationManager Navigation
 @using Ruvarr.Contracts
 @using Ruvarr.Blazor.Components.Shared
 
 <h1>Programs</h1>
+
+<div class="filter-bar">
+    <button class="filter-button @(Filter is null or "" ? "filter-button--active" : "")" @onclick='() => NavigateTo("")'>All</button>
+    <button class="filter-button @(Filter == "unmatched-programs" ? "filter-button--active" : "")" @onclick='() => NavigateTo("unmatched-programs")'>Unmatched Programs</button>
+    <button class="filter-button @(Filter == "unmatched-episodes" ? "filter-button--active" : "")" @onclick='() => NavigateTo("unmatched-episodes")'>Unmatched Episodes</button>
+    <button class="filter-button @(Filter == "missing-from-sonarr" ? "filter-button--active" : "")" @onclick='() => NavigateTo("missing-from-sonarr")'>Missing from Sonarr</button>
+</div>
+
+<div class="search-bar">
+    <input type="text" placeholder="Search programs..." @bind="_searchText" @bind:event="oninput" />
+</div>
 
 @if (_programs is null)
 {
@@ -12,105 +24,127 @@
 }
 else
 {
-    @foreach (ProgramSummary program in _programs)
+    IEnumerable<ProgramSummary> visible = string.IsNullOrWhiteSpace(_searchText)
+        ? _programs
+        : _programs.Where(p => p.ProgramName.Contains(_searchText, StringComparison.OrdinalIgnoreCase));
+
+    IReadOnlyList<ProgramSummary> visibleList = [.. visible];
+
+    if (visibleList.Count == 0)
     {
-        <details>
-            <summary style="display: flex; align-items: center;">
-                @program.ProgramName@if (program.SeriesName is not null) { <span class="program-series-name"> (@program.SeriesName)</span> }
-                <span style="margin-left: auto;">
-                    @if (_refreshing.Contains(program.ProgramRuvId))
+        <p>@GetEmptyMessage()</p>
+    }
+    else
+    {
+        @foreach (ProgramSummary program in visibleList)
+        {
+            <details>
+                <summary style="display: flex; align-items: center;">
+                    @program.ProgramName@if (program.SeriesName is not null) { <span class="program-series-name"> (@program.SeriesName)</span> }
+                    @if (program.HasMissingEpisodes)
                     {
-                        <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Refreshing">
-                            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                        </svg>
+                        <span class="badge badge--missing">missing</span>
                     }
-                    else
-                    {
-                        <button class="icon-button" @onclick="() => RefreshProgram(program.ProgramRuvId)" @onclick:stopPropagation title="Refresh">
-                            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Refresh">
-                                <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-                                <path d="M3 3v5h5" />
+                    <span style="margin-left: auto;">
+                        @if (_refreshing.Contains(program.ProgramRuvId))
+                        {
+                            <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Refreshing">
+                                <path d="M21 12a9 9 0 1 1-6.219-8.56" />
                             </svg>
-                        </button>
-                    }
-                </span>
-            </summary>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Season</th>
-                        <th>Episode</th>
-                        <th>First Run</th>
-                        <th>Title</th>
-                        <th>Description</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach (EpisodeSummary episode in program.Episodes)
-                    {
+                        }
+                        else
+                        {
+                            <button class="icon-button" @onclick="() => RefreshProgram(program.ProgramRuvId)" @onclick:stopPropagation title="Refresh">
+                                <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Refresh">
+                                    <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                                    <path d="M3 3v5h5" />
+                                </svg>
+                            </button>
+                        }
+                    </span>
+                </summary>
+                <table>
+                    <thead>
                         <tr>
-                            <td>@episode.SeasonNumber</td>
-                            <td>@episode.EpisodeNumber</td>
-                            <td>@episode.FirstRun.ToString("yyyy-MM-dd")</td>
-                            <td>@episode.EpisodeTitle</td>
-                            <td>@episode.EpisodeDescription</td>
-                            <td>
-                                <div class="row-actions">
-                                    @if (program.SeriesName is not null && episode.TvdbId is null)
-                                    {
-                                        <button class="icon-button" @onclick="() => OpenMatchDialog(episode.EpisodeRuvId)" title="Match to TVDB">
-                                            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Match to TVDB">
-                                                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-                                                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-                                            </svg>
-                                        </button>
-                                    }
-                                    @if (_downloading.Contains(episode.EpisodeRuvId))
-                                    {
-                                        <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Queuing">
-                                            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                                        </svg>
-                                    }
-                                    else if (_queued.Contains(episode.EpisodeRuvId))
-                                    {
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Queued">
-                                            <polyline points="20 6 9 17 4 12" />
-                                        </svg>
-                                    }
-                                    else if (_failed.Contains(episode.EpisodeRuvId))
-                                    {
-                                        <button class="icon-button icon-button--error" @onclick="() => Download(episode.EpisodeRuvId)" title="Retry">
-                                            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Retry">
-                                                <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-                                                <path d="M3 3v5h5" />
-                                            </svg>
-                                        </button>
-                                    }
-                                    else
-                                    {
-                                        <button class="icon-button" @onclick="() => Download(episode.EpisodeRuvId)" title="Download">
-                                            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Download">
-                                                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                                                <polyline points="7 10 12 15 17 10" />
-                                                <line x1="12" y1="15" x2="12" y2="3" />
-                                            </svg>
-                                        </button>
-                                    }
-                                </div>
-                            </td>
+                            <th>Season</th>
+                            <th>Episode</th>
+                            <th>First Run</th>
+                            <th>Title</th>
+                            <th>Description</th>
+                            <th></th>
                         </tr>
-                    }
-                </tbody>
-            </table>
-        </details>
+                    </thead>
+                    <tbody>
+                        @foreach (EpisodeSummary episode in program.Episodes)
+                        {
+                            <tr>
+                                <td>@episode.SeasonNumber</td>
+                                <td>@episode.EpisodeNumber</td>
+                                <td>@episode.FirstRun.ToString("yyyy-MM-dd")</td>
+                                <td>@episode.EpisodeTitle</td>
+                                <td>@episode.EpisodeDescription</td>
+                                <td>
+                                    <div class="row-actions">
+                                        @if (program.SeriesName is not null && episode.TvdbId is null)
+                                        {
+                                            <button class="icon-button" @onclick="() => OpenMatchDialog(episode.EpisodeRuvId)" title="Match to TVDB">
+                                                <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Match to TVDB">
+                                                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                                                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                                                </svg>
+                                            </button>
+                                        }
+                                        @if (_downloading.Contains(episode.EpisodeRuvId))
+                                        {
+                                            <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Queuing">
+                                                <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                                            </svg>
+                                        }
+                                        else if (_queued.Contains(episode.EpisodeRuvId))
+                                        {
+                                            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Queued">
+                                                <polyline points="20 6 9 17 4 12" />
+                                            </svg>
+                                        }
+                                        else if (_failed.Contains(episode.EpisodeRuvId))
+                                        {
+                                            <button class="icon-button icon-button--error" @onclick="() => Download(episode.EpisodeRuvId)" title="Retry">
+                                                <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Retry">
+                                                    <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                                                    <path d="M3 3v5h5" />
+                                                </svg>
+                                            </button>
+                                        }
+                                        else
+                                        {
+                                            <button class="icon-button" @onclick="() => Download(episode.EpisodeRuvId)" title="Download">
+                                                <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Download">
+                                                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                                                    <polyline points="7 10 12 15 17 10" />
+                                                    <line x1="12" y1="15" x2="12" y2="3" />
+                                                </svg>
+                                            </button>
+                                        }
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </details>
+        }
     }
 }
 
 <MatchEpisodeDialog @ref="_matchDialog" OnMatchComplete="ReloadAsync" />
 
 @code {
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "filter")]
+    public string? Filter { get; set; }
+
     private List<ProgramSummary>? _programs;
+    private string _searchText = string.Empty;
     private readonly HashSet<int> _refreshing = [];
     private readonly HashSet<string> _downloading = [];
     private readonly HashSet<string> _queued = [];
@@ -118,15 +152,27 @@ else
 
     private MatchEpisodeDialog? _matchDialog;
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnParametersSetAsync()
     {
-        _programs = await ApiClient.GetEpisodesAsync();
+        _programs = null;
+        _programs = await ApiClient.GetEpisodesAsync(Filter);
     }
 
-    private async Task ReloadAsync()
+    private Task ReloadAsync() => OnParametersSetAsync();
+
+    private void NavigateTo(string filter)
     {
-        _programs = await ApiClient.GetEpisodesAsync();
+        string url = string.IsNullOrEmpty(filter) ? "/" : $"/?filter={Uri.EscapeDataString(filter)}";
+        Navigation.NavigateTo(url);
     }
+
+    private string GetEmptyMessage() => Filter switch
+    {
+        "unmatched-programs" => "No unmatched programs found.",
+        "unmatched-episodes" => "No unmatched episodes found.",
+        "missing-from-sonarr" => "No programs with missing episodes found.",
+        _ => "No programs found.",
+    };
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
     private async Task RefreshProgram(int ruvId)

--- a/src/Ruvarr.Blazor/RuvApiClient.cs
+++ b/src/Ruvarr.Blazor/RuvApiClient.cs
@@ -10,13 +10,22 @@ internal sealed class RuvApiClient(HttpClient httpClient)
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
-    public Task<List<ProgramSummary>?> GetEpisodesAsync(CancellationToken cancellationToken = default)
-        => httpClient.GetFromJsonAsync<List<ProgramSummary>>("/programs/episodes", cancellationToken);
+    public Task<List<ProgramSummary>?> GetEpisodesAsync(
+        string? filter = null,
+        CancellationToken cancellationToken = default)
+    {
+        string queryString = filter switch
+        {
+            "unmatched-programs" => "?isProgramMatched=false",
+            "unmatched-episodes" => "?isProgramMatched=true&isEpisodeMatched=false",
+            "missing-from-sonarr" => "?isProgramMonitored=true&isProgramMissingEpisodes=true",
+            _ => string.Empty,
+        };
 
-    public Task<List<ProgramSummary>?> GetUnmatchedEpisodesAsync(CancellationToken cancellationToken = default)
-        => httpClient.GetFromJsonAsync<List<ProgramSummary>>(
-            "/programs/episodes?isProgramMissingEpisodes=true&isEpisodeMatched=false",
+        return httpClient.GetFromJsonAsync<List<ProgramSummary>>(
+            $"/programs/episodes{queryString}",
             cancellationToken);
+    }
 
     public Task<List<DownloadQueueItemSummary>?> GetDownloadQueueAsync(CancellationToken cancellationToken = default)
         => httpClient.GetFromJsonAsync<List<DownloadQueueItemSummary>>("/programs/download-queue", cancellationToken);

--- a/src/Ruvarr.Blazor/UnmatchedEpisodes/UnmatchedEpisodes.razor
+++ b/src/Ruvarr.Blazor/UnmatchedEpisodes/UnmatchedEpisodes.razor
@@ -1,84 +1,9 @@
 @page "/unmatched-episodes"
-@rendermode @(new InteractiveServerRenderMode(prerender: false))
-@inject RuvApiClient ApiClient
-@using Ruvarr.Contracts
-@using Ruvarr.Blazor.Components.Shared
-
-<h1>Unmatched Episodes</h1>
-
-@if (_programs is null)
-{
-    <div class="spinner"></div>
-}
-else if (_programs.Count == 0)
-{
-    <p>No unmatched episodes found.</p>
-}
-else
-{
-    @foreach (ProgramSummary program in _programs)
-    {
-        <details>
-            <summary>
-                @program.ProgramName@if (program.SeriesName is not null) { <span class="program-series-name"> (@program.SeriesName)</span> }
-            </summary>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Season</th>
-                        <th>Episode</th>
-                        <th>First Run</th>
-                        <th>Title</th>
-                        <th>Description</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach (EpisodeSummary episode in program.Episodes)
-                    {
-                        <tr>
-                            <td>@episode.SeasonNumber</td>
-                            <td>@episode.EpisodeNumber</td>
-                            <td>@episode.FirstRun.ToString("yyyy-MM-dd")</td>
-                            <td>@episode.EpisodeTitle</td>
-                            <td>@episode.EpisodeDescription</td>
-                            <td>
-                                <div class="row-actions">
-                                    <button class="icon-button" @onclick="() => OpenMatchDialog(episode.EpisodeRuvId)" title="Match to TVDB">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Match to TVDB">
-                                            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-                                            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-                                        </svg>
-                                    </button>
-                                </div>
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
-        </details>
-    }
-}
-
-<MatchEpisodeDialog @ref="_matchDialog" OnMatchComplete="ReloadAsync" />
+@inject NavigationManager Navigation
 
 @code {
-    private List<ProgramSummary>? _programs;
-    private MatchEpisodeDialog? _matchDialog;
-
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        _programs = await ApiClient.GetUnmatchedEpisodesAsync();
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
-    private async Task OpenMatchDialog(string ruvId)
-    {
-        await _matchDialog!.OpenAsync(ruvId);
-    }
-
-    private async Task ReloadAsync()
-    {
-        _programs = await ApiClient.GetUnmatchedEpisodesAsync();
+        Navigation.NavigateTo("/?filter=unmatched-episodes", replace: true);
     }
 }

--- a/src/Ruvarr.Blazor/wwwroot/app.css
+++ b/src/Ruvarr.Blazor/wwwroot/app.css
@@ -263,6 +263,78 @@ tbody tr:hover {
 .queue-status--downloading { color: #60a5fa; }
 .queue-status--complete { color: #4ade80; }
 
+.filter-bar {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    margin-bottom: 1rem;
+}
+
+.filter-button {
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    padding: 0.55rem 1rem;
+    color: rgba(255, 255, 255, 0.45);
+    font-size: 0.85rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+    white-space: nowrap;
+}
+
+.filter-button:hover {
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.filter-button--active {
+    color: #fff;
+    border-bottom-color: #fff;
+}
+
+.search-bar {
+    margin-bottom: 1.25rem;
+}
+
+.search-bar input {
+    background-color: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 4px;
+    color: #fff;
+    padding: 0.45rem 0.75rem;
+    font-size: 0.9rem;
+    width: 18rem;
+    transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.search-bar input::placeholder {
+    color: rgba(255, 255, 255, 0.3);
+}
+
+.search-bar input:focus {
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.35);
+    background-color: rgba(255, 255, 255, 0.07);
+}
+
+.badge {
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    padding: 0.15rem 0.45rem;
+    border-radius: 3px;
+    line-height: 1.4;
+}
+
+.badge--missing {
+    background-color: rgba(253, 70, 70, 0.18);
+    color: #fd6b6b;
+    border: 1px solid rgba(253, 70, 70, 0.3);
+}
+
 dialog {
     background-color: #2a2a2a;
     color: #fff;

--- a/src/Ruvarr.Contracts/EpisodeSummary.cs
+++ b/src/Ruvarr.Contracts/EpisodeSummary.cs
@@ -7,4 +7,5 @@ public sealed record EpisodeSummary(
     int? TvdbId,
     int? SeasonNumber,
     int? EpisodeNumber,
-    DateTime FirstRun);
+    DateTime FirstRun,
+    bool IsMissing);

--- a/src/Ruvarr.Contracts/ProgramSummary.cs
+++ b/src/Ruvarr.Contracts/ProgramSummary.cs
@@ -4,5 +4,7 @@ public sealed record ProgramSummary(
     string Channel,
     string ProgramName,
     int ProgramRuvId,
+    bool IsMonitored,
+    bool HasMissingEpisodes,
     string? SeriesName,
     IReadOnlyList<EpisodeSummary> Episodes);

--- a/src/Ruvarr/Programs/Queries/GetEpisodes/GetEpisodesHandler.cs
+++ b/src/Ruvarr/Programs/Queries/GetEpisodes/GetEpisodesHandler.cs
@@ -12,9 +12,9 @@ internal sealed class GetEpisodesHandler(RuvarrDbContext dbContext, ISonarrClien
 {
     public async Task<List<ProgramSummary>> Handle(GetEpisodesQuery request, CancellationToken cancellationToken)
     {
-        IReadOnlyCollection<MissingEpisode> missingEpisodes = request.IsEpisodeMissing is not null
-            ? await sonarr.GetMissingEpisodesAsync(cancellationToken: cancellationToken)
-            : [];
+        IReadOnlyCollection<MissingEpisode> missingEpisodes = await sonarr.GetMissingEpisodesAsync(cancellationToken: cancellationToken);
+
+        HashSet<int?> missingTvdbIds = [.. missingEpisodes.Select(x => x.TvdbId)];
 
         IQueryable<RuvEpisode> query = dbContext.Set<RuvEpisode>();
 
@@ -40,8 +40,7 @@ internal sealed class GetEpisodesHandler(RuvarrDbContext dbContext, ISonarrClien
 
         if (request.IsEpisodeMissing is not null)
         {
-            HashSet<int?> missingEpisodeIds = [.. missingEpisodes.Select(x => x.TvdbId)];
-            query = query.Where(x => missingEpisodeIds.Contains(x.TvdbId));
+            query = query.Where(x => missingTvdbIds.Contains(x.TvdbId) == request.IsEpisodeMissing);
         }
 
         if (request.IsProgramMatched is not null)
@@ -63,6 +62,8 @@ internal sealed class GetEpisodesHandler(RuvarrDbContext dbContext, ISonarrClien
                 x.Program.Channel,
                 ProgramName = x.Program.Name,
                 ProgramRuvId = x.Program.RuvId,
+                IsMonitored = x.Program.IsMonitored,
+                HasMissingEpisodes = x.Program.HasMissingEpisodes,
                 SeriesName = x.Program.Series!.Name,
                 EpisodeTitle = x.Title,
                 EpisodeRuvId = x.RuvId,
@@ -74,12 +75,14 @@ internal sealed class GetEpisodesHandler(RuvarrDbContext dbContext, ISonarrClien
             })
             .ToListAsync(cancellationToken);
 
-        return [.. flat
+        IEnumerable<ProgramSummary> programs = flat
             .GroupBy(x => x.ProgramRuvId)
             .Select(g => new ProgramSummary(
                 g.First().Channel,
                 g.First().ProgramName,
                 g.Key,
+                g.First().IsMonitored,
+                g.First().HasMissingEpisodes,
                 g.First().SeriesName,
                 [.. g.Select(e => new EpisodeSummary(
                     e.EpisodeTitle,
@@ -88,7 +91,15 @@ internal sealed class GetEpisodesHandler(RuvarrDbContext dbContext, ISonarrClien
                     e.TvdbId,
                     e.SeasonNumber,
                     e.EpisodeNumber,
-                    e.FirstRun))]))
-            .OrderBy(p => p.ProgramName)];
+                    e.FirstRun,
+                    missingTvdbIds.Contains(e.TvdbId)))]))
+            .OrderBy(p => p.ProgramName);
+
+        if (request.IsProgramMissingEpisodes == true)
+        {
+            programs = programs.Where(p => p.Episodes.Any(e => e.IsMissing));
+        }
+
+        return [.. programs];
     }
 }


### PR DESCRIPTION
Merges the separate Unmatched Episodes page into a single Programs page with URL-based filter presets (all, unmatched-programs, unmatched-episodes, missing-from-sonarr) and a client-side text search. Adds IsMonitored, HasMissingEpisodes to ProgramSummary and IsMissing to EpisodeSummary. Always fetches Sonarr missing episodes so IsMissing is always populated. The /unmatched-episodes route now redirects to /?filter=unmatched-episodes.