### PR TITLE
feat(programs): show loading indicator in match episode dialog while …

### DIFF
--- a/src/Ruvarr.Blazor/Components/Shared/MatchEpisodeDialog.razor
+++ b/src/Ruvarr.Blazor/Components/Shared/MatchEpisodeDialog.razor
@@ -8,8 +8,14 @@
         <input type="number" min="1" @bind="_tvdbIdInput" @bind:event="oninput" />
     </label>
     <div class="dialog-actions">
-        <button class="dialog-button dialog-button--primary" @onclick="SubmitMatch">Match</button>
-        <button class="dialog-button" @onclick="CloseAsync">Cancel</button>
+        <button class="dialog-button dialog-button--primary" @onclick="SubmitMatch" disabled="@_isSubmitting">
+            @if (_isSubmitting)
+            {
+                <span class="button-spinner"></span>
+            }
+            Match
+        </button>
+        <button class="dialog-button" @onclick="CloseAsync" disabled="@_isSubmitting">Cancel</button>
     </div>
 </dialog>
 
@@ -20,6 +26,7 @@
     private ElementReference _dialog;
     private string? _ruvId;
     private string _tvdbIdInput = string.Empty;
+    private bool _isSubmitting;
 
     public async Task OpenAsync(string ruvId)
     {
@@ -48,7 +55,15 @@
             return;
         }
 
-        await ApiClient.MatchEpisodeAsync(_ruvId, tvdbId);
+        _isSubmitting = true;
+        try
+        {
+            await ApiClient.MatchEpisodeAsync(_ruvId, tvdbId);
+        }
+        finally
+        {
+            _isSubmitting = false;
+        }
         await CloseAsync();
         await OnMatchComplete.InvokeAsync();
     }

--- a/src/Ruvarr.Blazor/Programs/Programs.razor
+++ b/src/Ruvarr.Blazor/Programs/Programs.razor
@@ -144,6 +144,7 @@ else
     public string? Filter { get; set; }
 
     private List<ProgramSummary>? _programs;
+    private string? _loadedFilter;
     private string _searchText = string.Empty;
     private readonly HashSet<int> _refreshing = [];
     private readonly HashSet<string> _downloading = [];
@@ -154,6 +155,11 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
+        if (_loadedFilter == Filter)
+        {
+            return;
+        }
+
         _programs = null;
         await LoadProgramsAsync();
     }
@@ -163,6 +169,7 @@ else
     private async Task LoadProgramsAsync()
     {
         _programs = await ApiClient.GetEpisodesAsync(Filter);
+        _loadedFilter = Filter;
     }
 
     private void NavigateTo(string filter)

--- a/src/Ruvarr.Blazor/wwwroot/app.css
+++ b/src/Ruvarr.Blazor/wwwroot/app.css
@@ -411,3 +411,25 @@ dialog input[type="number"]:focus {
 .dialog-button--primary:hover {
     background-color: rgba(255, 255, 255, 0.18);
 }
+
+.dialog-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.button-spinner {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    margin-right: 6px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+    vertical-align: middle;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
…submitting

Disables both buttons and shows an inline spinner inside the Match button while the API call is in progress. Also fixes a spurious page-level loading spinner that appeared after matching by tracking the loaded filter value and skipping the null reset in OnParametersSetAsync when the filter hasn't changed.