### PR TITLE
feat(programs): add partially-matched programs filter

### DIFF
--- a/src/Ruvarr.Api/Programs/Queries/GetProgramsEndpoint.cs
+++ b/src/Ruvarr.Api/Programs/Queries/GetProgramsEndpoint.cs
@@ -19,6 +19,7 @@ internal static class GetProgramsEndpoint
             [FromQuery] bool? isProgramMonitored,
             [FromQuery] bool? isProgramMissingEpisodes,
             [FromQuery] bool? isProgramMatched,
+            [FromQuery] bool? isProgramPartiallyMatched,
             [FromQuery] bool? isEpisodeMatched,
             [FromQuery] bool? isEpisodeMissing,
             CancellationToken cancellationToken) =>
@@ -29,6 +30,7 @@ internal static class GetProgramsEndpoint
                 IsProgramMonitored: isProgramMonitored,
                 IsProgramMissingEpisodes: isProgramMissingEpisodes,
                 IsProgramMatched: isProgramMatched,
+                IsProgramPartiallyMatched: isProgramPartiallyMatched,
                 IsEpisodeMatched: isEpisodeMatched,
                 IsEpisodeMissing: isEpisodeMissing);
 

--- a/src/Ruvarr.Blazor/Programs/Programs.razor
+++ b/src/Ruvarr.Blazor/Programs/Programs.razor
@@ -12,6 +12,7 @@
     <button class="filter-button @(Filter == "unmatched-programs" ? "filter-button--active" : "")" @onclick='() => NavigateTo("unmatched-programs")'>Unmatched Programs</button>
     <button class="filter-button @(Filter == "unmatched-episodes" ? "filter-button--active" : "")" @onclick='() => NavigateTo("unmatched-episodes")'>Unmatched Episodes</button>
     <button class="filter-button @(Filter == "missing-from-sonarr" ? "filter-button--active" : "")" @onclick='() => NavigateTo("missing-from-sonarr")'>Missing from Sonarr</button>
+    <button class="filter-button @(Filter == "partially-matched" ? "filter-button--active" : "")" @onclick='() => NavigateTo("partially-matched")'>Partially Matched</button>
 </div>
 
 <div class="search-bar">
@@ -183,6 +184,7 @@ else
         "unmatched-programs" => "No unmatched programs found.",
         "unmatched-episodes" => "No unmatched episodes found.",
         "missing-from-sonarr" => "No programs with missing episodes found.",
+        "partially-matched" => "No partially matched programs found.",
         _ => "No programs found.",
     };
 

--- a/src/Ruvarr.Blazor/RuvApiClient.cs
+++ b/src/Ruvarr.Blazor/RuvApiClient.cs
@@ -19,6 +19,7 @@ internal sealed class RuvApiClient(HttpClient httpClient)
             "unmatched-programs" => "?isProgramMatched=false",
             "unmatched-episodes" => "?isProgramMatched=true&isEpisodeMatched=false",
             "missing-from-sonarr" => "?isProgramMonitored=true&isProgramMissingEpisodes=true",
+            "partially-matched" => "?isProgramPartiallyMatched=true",
             _ => string.Empty,
         };
 

--- a/src/Ruvarr/Programs/Queries/GetEpisodes/GetEpisodesHandler.cs
+++ b/src/Ruvarr/Programs/Queries/GetEpisodes/GetEpisodesHandler.cs
@@ -2,9 +2,9 @@
 
 using Ruvarr.Abstractions;
 using Ruvarr.Contracts;
-using Ruvarr.Programs.Domain;
 using Ruvarr.Infrastructure.Sonarr;
 using Ruvarr.Infrastructure.Sonarr.Models;
+using Ruvarr.Programs.Domain;
 
 namespace Ruvarr.Programs.Queries.GetEpisodes;
 
@@ -48,6 +48,14 @@ internal sealed class GetEpisodesHandler(RuvarrDbContext dbContext, ISonarrClien
             query = query.Where(x => (x.Program.Series == null) != request.IsProgramMatched);
         }
 
+        if (request.IsProgramPartiallyMatched is true)
+        {
+            query = query.Where(x =>
+                x.Program.Series != null &&
+                x.Program.Episodes.Any(e => e.TvdbId != null) &&
+                x.Program.Episodes.Any(e => e.TvdbId == null));
+        }
+
         if (request.IsEpisodeMatched is not null)
         {
             query = query.Where(x => (x.TvdbId == null) != request.IsEpisodeMatched);
@@ -62,8 +70,8 @@ internal sealed class GetEpisodesHandler(RuvarrDbContext dbContext, ISonarrClien
                 x.Program.Channel,
                 ProgramName = x.Program.Name,
                 ProgramRuvId = x.Program.RuvId,
-                IsMonitored = x.Program.IsMonitored,
-                HasMissingEpisodes = x.Program.HasMissingEpisodes,
+                x.Program.IsMonitored,
+                x.Program.HasMissingEpisodes,
                 SeriesName = x.Program.Series!.Name,
                 EpisodeTitle = x.Title,
                 EpisodeRuvId = x.RuvId,

--- a/src/Ruvarr/Programs/Queries/GetEpisodes/GetEpisodesQuery.cs
+++ b/src/Ruvarr/Programs/Queries/GetEpisodes/GetEpisodesQuery.cs
@@ -6,5 +6,6 @@ public sealed record class GetEpisodesQuery(
     bool? IsProgramMonitored,
     bool? IsProgramMissingEpisodes,
     bool? IsProgramMatched,
+    bool? IsProgramPartiallyMatched,
     bool? IsEpisodeMatched,
     bool? IsEpisodeMissing);

--- a/tests/Ruvarr.IntegrationTests/Programs/Episodes/Queries/GetEpisodesPartiallyMatchedTests.cs
+++ b/tests/Ruvarr.IntegrationTests/Programs/Episodes/Queries/GetEpisodesPartiallyMatchedTests.cs
@@ -1,0 +1,154 @@
+using System.Net.Http.Json;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Ruvarr.Contracts;
+using Ruvarr.Programs.Domain;
+
+using Shouldly;
+
+namespace Ruvarr.IntegrationTests.Programs.Episodes.Queries;
+
+public sealed class GetEpisodesPartiallyMatchedTests(IntegrationTestFactory factory) : IClassFixture<IntegrationTestFactory>
+{
+    [Fact]
+    public async Task ReturnsPartiallyMatchedPrograms_WhenFilterIsSet()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+
+        RuvProgram program = RuvProgram.Create(10001, "RÚV1", "Partially Matched Show", null, multipleEpisodes: true);
+        program.MatchTvdb(TvdbSeries.Create("1001", "Some Series"));
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        program.TryAddEpisode("PM-EP1", new Uri("https://example.com/ep1.mp4"), "Episode 1", "Desc", DateTime.UtcNow);
+        program.TryAddEpisode("PM-EP2", new Uri("https://example.com/ep2.mp4"), "Episode 2", "Desc", DateTime.UtcNow);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        program.Episodes[0].Match(tvdbId: 5001, season: 1, episode: 1, isMissing: false);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary>? result = await factory.CreateClient()
+            .GetFromJsonAsync<List<ProgramSummary>>("/programs/episodes?isProgramPartiallyMatched=true", cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldContain(p => p.ProgramRuvId == 10001);
+    }
+
+    [Fact]
+    public async Task ExcludesFullyMatchedPrograms_WhenPartiallyMatchedFilterIsSet()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+
+        RuvProgram program = RuvProgram.Create(10002, "RÚV1", "Fully Matched Show", null, multipleEpisodes: true);
+        program.MatchTvdb(TvdbSeries.Create("1002", "Fully Matched Series"));
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        program.TryAddEpisode("FM-EP1", new Uri("https://example.com/ep1.mp4"), "Episode 1", "Desc", DateTime.UtcNow);
+        program.TryAddEpisode("FM-EP2", new Uri("https://example.com/ep2.mp4"), "Episode 2", "Desc", DateTime.UtcNow);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        program.Episodes[0].Match(tvdbId: 5002, season: 1, episode: 1, isMissing: false);
+        program.Episodes[1].Match(tvdbId: 5003, season: 1, episode: 2, isMissing: false);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary>? result = await factory.CreateClient()
+            .GetFromJsonAsync<List<ProgramSummary>>("/programs/episodes?isProgramPartiallyMatched=true", cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldNotContain(p => p.ProgramRuvId == 10002);
+    }
+
+    [Fact]
+    public async Task ExcludesFullyUnmatchedPrograms_WhenPartiallyMatchedFilterIsSet()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+
+        RuvProgram program = RuvProgram.Create(10003, "RÚV1", "Fully Unmatched Show", null, multipleEpisodes: true);
+        program.MatchTvdb(TvdbSeries.Create("1003", "Fully Unmatched Series"));
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        program.TryAddEpisode("FU-EP1", new Uri("https://example.com/ep1.mp4"), "Episode 1", "Desc", DateTime.UtcNow);
+        program.TryAddEpisode("FU-EP2", new Uri("https://example.com/ep2.mp4"), "Episode 2", "Desc", DateTime.UtcNow);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary>? result = await factory.CreateClient()
+            .GetFromJsonAsync<List<ProgramSummary>>("/programs/episodes?isProgramPartiallyMatched=true", cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldNotContain(p => p.ProgramRuvId == 10003);
+    }
+
+    [Fact]
+    public async Task ExcludesMoviePrograms_WhenPartiallyMatchedFilterIsSet()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+
+        RuvProgram program = RuvProgram.Create(10004, "RÚV1", "Some Movie", null, multipleEpisodes: false);
+        program.MatchTmdb(TmdbMovie.Create(9001, "Some Movie"));
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        program.TryAddEpisode("MOV-EP1", new Uri("https://example.com/ep1.mp4"), "Part 1", "Desc", DateTime.UtcNow);
+        program.TryAddEpisode("MOV-EP2", new Uri("https://example.com/ep2.mp4"), "Part 2", "Desc", DateTime.UtcNow);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        program.Episodes[0].Match(tvdbId: 5010, season: 1, episode: 1, isMissing: false);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary>? result = await factory.CreateClient()
+            .GetFromJsonAsync<List<ProgramSummary>>("/programs/episodes?isProgramPartiallyMatched=true", cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldNotContain(p => p.ProgramRuvId == 10004);
+    }
+
+    [Fact]
+    public async Task ExcludesProgramsWithNoEpisodes_WhenPartiallyMatchedFilterIsSet()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+
+        RuvProgram program = RuvProgram.Create(10005, "RÚV1", "No Episodes Show", null, multipleEpisodes: true);
+        program.MatchTvdb(TvdbSeries.Create("1005", "No Episodes Series"));
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary>? result = await factory.CreateClient()
+            .GetFromJsonAsync<List<ProgramSummary>>("/programs/episodes?isProgramPartiallyMatched=true", cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldNotContain(p => p.ProgramRuvId == 10005);
+    }
+}


### PR DESCRIPTION
Adds a new filter that shows programs where at least one episode has a TvdbId and at least one does not. Movies and programs with no episodes are excluded from results.