### PR TITLE
feat(programs): drive refresh status icons from SSE stream

### DIFF
--- a/src/Ruvarr.Blazor/Programs/Programs.razor
+++ b/src/Ruvarr.Blazor/Programs/Programs.razor
@@ -1,5 +1,6 @@
 @page "/"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
+@implements IAsyncDisposable
 @inject RuvApiClient ApiClient
 @inject NavigationManager Navigation
 @using Ruvarr.Contracts
@@ -47,11 +48,22 @@ else
                         <span class="badge badge--missing">missing</span>
                     }
                     <span style="margin-left: auto;">
-                        @if (_refreshing.Contains(program.ProgramRuvId))
+                        @if (_refreshQueue.TryGetValue(program.ProgramRuvId, out ProgramRefreshStatus status) && status == ProgramRefreshStatus.Processing)
                         {
-                            <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Refreshing">
-                                <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                            </svg>
+                            <span class="icon-button">
+                                <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Refreshing">
+                                    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                                </svg>
+                            </span>
+                        }
+                        else if (_refreshQueue.ContainsKey(program.ProgramRuvId) || _pendingRefresh.Contains(program.ProgramRuvId))
+                        {
+                            <span class="icon-button">
+                                <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Pending">
+                                    <circle cx="12" cy="12" r="10" />
+                                    <polyline points="12 6 12 12 16 14" />
+                                </svg>
+                            </span>
                         }
                         else
                         {
@@ -147,12 +159,39 @@ else
     private List<ProgramSummary>? _programs;
     private string? _loadedFilter;
     private string _searchText = string.Empty;
-    private readonly HashSet<int> _refreshing = [];
+    private readonly HashSet<int> _pendingRefresh = [];
+    private Dictionary<int, ProgramRefreshStatus> _refreshQueue = [];
+    private readonly CancellationTokenSource _cts = new();
     private readonly HashSet<string> _downloading = [];
     private readonly HashSet<string> _queued = [];
     private readonly HashSet<string> _failed = [];
 
     private MatchEpisodeDialog? _matchDialog;
+
+    protected override Task OnInitializedAsync()
+    {
+        _ = WatchAsync();
+        return Task.CompletedTask;
+    }
+
+    private async Task WatchAsync()
+    {
+        await foreach (List<ProgramRefreshQueueItemSummary> items in ApiClient.WatchProgramRefreshQueueAsync(_cts.Token))
+        {
+            _refreshQueue = items.ToDictionary(x => x.RuvId, x => x.Status);
+            foreach (int ruvId in _pendingRefresh.Where(id => _refreshQueue.ContainsKey(id)).ToList())
+            {
+                _pendingRefresh.Remove(ruvId);
+            }
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cts.CancelAsync();
+        _cts.Dispose();
+    }
 
     protected override async Task OnParametersSetAsync()
     {
@@ -191,9 +230,8 @@ else
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
     private async Task RefreshProgram(int ruvId)
     {
-        _refreshing.Add(ruvId);
+        _pendingRefresh.Add(ruvId);
         await ApiClient.RefreshProgramAsync(ruvId);
-        _refreshing.Remove(ruvId);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]


### PR DESCRIPTION
Replace client-side _refreshing HashSet with server-driven state via the existing SSE queue. Pending and Processing states now reflect real server state, including scheduled refreshes triggered without user interaction.