### PR TITLE
fix: remove missing badge from programs list

### DIFF
--- a/src/Ruvarr.Blazor/Programs/Programs.razor
+++ b/src/Ruvarr.Blazor/Programs/Programs.razor
@@ -43,10 +43,6 @@ else
                      @ontoggle="() => OnToggle(program.ProgramRuvId)">
                 <summary style="display: flex; align-items: center;">
                     @program.ProgramName@if (program.SeriesName is not null) { <span class="program-series-name"> (@program.SeriesName)</span> }
-                    @if (program.HasMissingEpisodes)
-                    {
-                        <span class="badge badge--missing">missing</span>
-                    }
                     <span style="margin-left: auto;">
                         @if (_refreshQueue.TryGetValue(program.ProgramRuvId, out ProgramRefreshStatus status) && status == ProgramRefreshStatus.Processing)
                         {

--- a/src/Ruvarr.Blazor/wwwroot/app.css
+++ b/src/Ruvarr.Blazor/wwwroot/app.css
@@ -319,22 +319,6 @@ tbody tr:hover {
     background-color: rgba(255, 255, 255, 0.07);
 }
 
-.badge {
-    font-size: 0.65rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.07em;
-    padding: 0.15rem 0.45rem;
-    border-radius: 3px;
-    line-height: 1.4;
-}
-
-.badge--missing {
-    background-color: rgba(253, 70, 70, 0.18);
-    color: #fd6b6b;
-    border: 1px solid rgba(253, 70, 70, 0.3);
-}
-
 dialog {
     background-color: #2a2a2a;
     color: #fff;


### PR DESCRIPTION
## Summary
- Removes the inline red \"missing\" badge rendered next to program names in the programs list
- Deletes dead `.badge` and `.badge--missing` CSS rules from `app.css`

## Test plan
- [ ] Verify no \"missing\" badge appears next to program names in the list
- [ ] Verify the \"Missing from Sonarr\" filter button still works

Closes #62