### PR TITLE
feat: expose TvdbUrl in ProgramSummary for programs with a TVDB slug

### DIFF
--- a/src/Ruvarr.Contracts/ProgramSummary.cs
+++ b/src/Ruvarr.Contracts/ProgramSummary.cs
@@ -6,4 +6,5 @@ public sealed record ProgramSummary(
     int ProgramRuvId,
     bool IsMonitored,
     bool HasMissingEpisodes,
-    string? SeriesName);
+    string? SeriesName,
+    Uri? TvdbUrl);

--- a/src/Ruvarr/Programs/Domain/TvdbSeries.cs
+++ b/src/Ruvarr/Programs/Domain/TvdbSeries.cs
@@ -1,6 +1,8 @@
-﻿namespace Ruvarr.Programs.Domain;
+﻿using System.Text.RegularExpressions;
 
-internal sealed class TvdbSeries
+namespace Ruvarr.Programs.Domain;
+
+internal sealed partial class TvdbSeries
 {
     private readonly List<RuvProgram> _programs = [];
 
@@ -16,8 +18,13 @@ internal sealed class TvdbSeries
 
     public IReadOnlyList<RuvProgram> Programs => [.. _programs];
 
+    [GeneratedRegex(@"^[a-z0-9\-]{1,128}$")]
+    private static partial Regex SlugPattern();
+
     internal void UpdateSlug(string? slug)
     {
+        if (slug is not null && !SlugPattern().IsMatch(slug))
+            return;
         Slug = slug;
     }
 
@@ -30,7 +37,7 @@ internal sealed class TvdbSeries
         {
             TvdbId = id,
             Name = name,
-            Slug = slug
+            Slug = slug is not null && SlugPattern().IsMatch(slug) ? slug : null
         };
     }
 }

--- a/src/Ruvarr/Programs/Queries/GetEpisodes/GetEpisodesHandler.cs
+++ b/src/Ruvarr/Programs/Queries/GetEpisodes/GetEpisodesHandler.cs
@@ -88,7 +88,7 @@ internal sealed class GetEpisodesHandler(RuvarrDbContext dbContext) : IRequestHa
                 g.First().IsMonitored,
                 g.First().HasMissingEpisodes,
                 g.First().SeriesName,
-                g.First().SeriesSlug is { } slug ? new Uri($"https://www.thetvdb.com/series/{slug}") : null,
+                g.First().SeriesSlug is { } slug ? new Uri($"https://www.thetvdb.com/series/{Uri.EscapeDataString(slug)}") : null,
                 [.. g.Select(e => new EpisodeSummary(
                     e.EpisodeTitle,
                     e.EpisodeRuvId,

--- a/src/Ruvarr/Programs/Queries/GetPrograms/GetProgramsHandler.cs
+++ b/src/Ruvarr/Programs/Queries/GetPrograms/GetProgramsHandler.cs
@@ -46,14 +46,25 @@ internal sealed class GetProgramsHandler(RuvarrDbContext dbContext) : IStreaming
 
         IAsyncEnumerable<ProgramSummary> results = query
             .OrderBy(x => x.Name)
+            .Select(x => new
+            {
+                x.Channel,
+                x.Name,
+                x.RuvId,
+                x.IsMonitored,
+                x.HasMissingEpisodes,
+                SeriesName = x.Series!.Name,
+                SeriesSlug = x.Series!.Slug,
+            })
+            .AsAsyncEnumerable()
             .Select(x => new ProgramSummary(
                 x.Channel,
                 x.Name,
                 x.RuvId,
                 x.IsMonitored,
                 x.HasMissingEpisodes,
-                x.Series!.Name))
-            .AsAsyncEnumerable();
+                x.SeriesName,
+                x.SeriesSlug is { } slug ? new Uri($"https://www.thetvdb.com/series/{Uri.EscapeDataString(slug)}") : null));
 
         await foreach (ProgramSummary summary in results.WithCancellation(cancellationToken))
         {

--- a/tests/Ruvarr.IntegrationTests/Programs/Queries/GetProgramsTests.cs
+++ b/tests/Ruvarr.IntegrationTests/Programs/Queries/GetProgramsTests.cs
@@ -135,4 +135,106 @@ public sealed class GetProgramsTests(IntegrationTestFactory factory) : IClassFix
         result.ShouldContain(p => p.ProgramRuvId == 20020);
         result.ShouldNotContain(p => p.ProgramRuvId == 20021);
     }
+
+    [Fact]
+    public async Task ReturnsTvdbUrlWhenSeriesHasSlug()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+
+        RuvProgram program = RuvProgram.Create(20022, "RÚV1", "Series With Slug", null, multipleEpisodes: true);
+        program.MatchTvdb(TvdbSeries.Create("3001", "Series With Slug", slug: "some-slug"));
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary>? result = await factory.CreateClient()
+            .GetFromJsonAsync<List<ProgramSummary>>("/programs", cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        ProgramSummary? found = result.FirstOrDefault(p => p.ProgramRuvId == 20022);
+        found.ShouldNotBeNull();
+        found.TvdbUrl.ShouldBe(new Uri("https://www.thetvdb.com/series/some-slug"));
+    }
+
+    [Fact]
+    public async Task ReturnsTvdbUrlAsNullWhenSeriesHasNullSlug()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+
+        RuvProgram program = RuvProgram.Create(20023, "RÚV1", "Series Without Slug", null, multipleEpisodes: true);
+        program.MatchTvdb(TvdbSeries.Create("3002", "Series Without Slug"));
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary>? result = await factory.CreateClient()
+            .GetFromJsonAsync<List<ProgramSummary>>("/programs", cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        ProgramSummary? found = result.FirstOrDefault(p => p.ProgramRuvId == 20023);
+        found.ShouldNotBeNull();
+        found.TvdbUrl.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ReturnsTvdbUrlAsNullWhenProgramIsUnmatched()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+
+        RuvProgram program = RuvProgram.Create(20024, "RÚV1", "Unmatched Program", null, multipleEpisodes: true);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary>? result = await factory.CreateClient()
+            .GetFromJsonAsync<List<ProgramSummary>>("/programs", cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        ProgramSummary? found = result.FirstOrDefault(p => p.ProgramRuvId == 20024);
+        found.ShouldNotBeNull();
+        found.TvdbUrl.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ReturnsTvdbUrlAsNullWhenSlugIsMalformed()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+
+        TvdbSeries series = TvdbSeries.Create("4001", "Series With Bad Slug");
+        series.UpdateSlug("bad?slug=1");
+
+        RuvProgram program = RuvProgram.Create(20025, "RÚV1", "Series With Bad Slug", null, multipleEpisodes: true);
+        program.MatchTvdb(series);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary>? result = await factory.CreateClient()
+            .GetFromJsonAsync<List<ProgramSummary>>("/programs", cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        ProgramSummary? found = result.FirstOrDefault(p => p.ProgramRuvId == 20025);
+        found.ShouldNotBeNull();
+        found.TvdbUrl.ShouldBeNull();
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `Uri? TvdbUrl` to `ProgramSummary` returned by `GET /programs`, consistent with the existing field in `ProgramDetails`
- Uses a two-step EF Core projection to construct the `Uri` client-side after `.AsAsyncEnumerable()`
- Adds allowlist validation (`^[a-z0-9\-]{1,128}$`) on `TvdbSeries.Slug` at the write boundary and `Uri.EscapeDataString` at the read boundary

## Test plan
- [ ] `ReturnsTvdbUrlWhenSeriesHasSlug` — slug present → correct URL
- [ ] `ReturnsTvdbUrlAsNullWhenSeriesHasNullSlug` — slug null → null
- [ ] `ReturnsTvdbUrlAsNullWhenProgramIsUnmatched` — no TVDB match → null
- [ ] `ReturnsTvdbUrlAsNullWhenSlugIsMalformed` — invalid slug discarded → null

Closes #61