### PR TITLE
feat: add TVDB badge link in expanded program details

### DIFF
--- a/src/Ruvarr.Blazor/Programs/Programs.razor
+++ b/src/Ruvarr.Blazor/Programs/Programs.razor
@@ -72,6 +72,10 @@ else
                         }
                     </span>
                 </summary>
+                @if (program.TvdbUrl is not null)
+                {
+                    <a class="badge--tvdb" href="@program.TvdbUrl" target="_blank" rel="noopener noreferrer">TVDB</a>
+                }
                 @if (_loadingEpisodes.Contains(program.ProgramRuvId))
                 {
                     <div class="spinner"></div>

--- a/src/Ruvarr.Blazor/wwwroot/app.css
+++ b/src/Ruvarr.Blazor/wwwroot/app.css
@@ -417,3 +417,21 @@ dialog input[type="number"]:focus {
 @keyframes spin {
     to { transform: rotate(360deg); }
 }
+
+.badge--tvdb {
+    display: inline-block;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border-radius: 4px;
+    border: 1px solid #60a5fa;
+    color: #60a5fa;
+    text-decoration: none;
+    margin-bottom: 0.5rem;
+}
+
+.badge--tvdb:hover {
+    opacity: 0.8;
+}


### PR DESCRIPTION
## Summary
- Adds a "TVDB" badge link inside the expanded details body of each program, above the episode table
- The badge only renders when `TvdbUrl` is non-null (program matched to a TVDB series)
- Opens in a new tab with `rel="noopener noreferrer"`

## Test plan
- [ ] Expand a program matched to a TVDB series — verify the "TVDB" badge appears above the episode table
- [ ] Click the badge — verify it opens the TVDB series page in a new tab
- [ ] Expand a program with no TVDB match — verify no badge or placeholder renders
- [ ] Expand a matched program while episodes are still loading — verify the badge appears above the spinner

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)