### PR TITLE
Queue TVDB episode lookup immediately on program refresh

### DIFF
--- a/src/Ruvarr/Programs/Commands/RefreshProgram/RefreshProgramHandler.cs
+++ b/src/Ruvarr/Programs/Commands/RefreshProgram/RefreshProgramHandler.cs
@@ -5,12 +5,13 @@ using Ruvarr.Programs.Domain;
 
 namespace Ruvarr.Programs.Commands.RefreshProgram;
 
-internal sealed class RefreshProgramHandler(RuvarrDbContext dbContext, ProgramRefreshNotifier syncQueue)
+internal sealed class RefreshProgramHandler(RuvarrDbContext dbContext, ProgramRefreshNotifier syncQueue, TvdbEpisodeLookupNotifier tvdbEpisodeLookupNotifier)
     : IRequestHandler<RefreshProgramCommand>
 {
     public async Task<RuvarrResult> Handle(RefreshProgramCommand command, CancellationToken cancellationToken)
     {
         RuvProgram? program = await dbContext.Set<RuvProgram>()
+            .Include(p => p.Series)
             .Where(p => p.RuvId == command.RuvId)
             .FirstOrDefaultAsync(cancellationToken);
 
@@ -20,6 +21,11 @@ internal sealed class RefreshProgramHandler(RuvarrDbContext dbContext, ProgramRe
         }
 
         syncQueue.Enqueue(program.RuvId, program.Name);
+
+        if (program.Series is not null && program.HasMultipleEpisodes)
+        {
+            tvdbEpisodeLookupNotifier.Enqueue(program.RuvId, program.Name);
+        }
 
         return RuvarrResult.Success;
     }

--- a/tests/Ruvarr.UnitTests/Programs/Commands/RefreshProgramHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Commands/RefreshProgramHandlerTests/Handle.cs
@@ -1,0 +1,111 @@
+using Microsoft.EntityFrameworkCore;
+
+using NSubstitute;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Programs;
+using Ruvarr.Programs.Commands.RefreshProgram;
+using Ruvarr.Programs.Domain;
+using Ruvarr.UnitTests.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.Commands.RefreshProgramHandlerTests;
+
+public sealed class Handle
+{
+    private readonly TvdbEpisodeLookupNotifier _tvdbEpisodeLookupNotifier = new();
+    private readonly ProgramRefreshNotifier _programRefreshNotifier = new();
+    private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
+
+    public Handle()
+    {
+        _serviceProvider.GetService(Arg.Any<Type>()).Returns(Array.Empty<object>());
+    }
+
+    private RuvarrDbContext CreateDbContext() => new(
+        new DbContextOptionsBuilder<RuvarrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options,
+        _serviceProvider);
+
+    private RefreshProgramHandler CreateHandler(RuvarrDbContext dbContext) => new(
+        dbContext, _programRefreshNotifier, _tvdbEpisodeLookupNotifier);
+
+    [Fact]
+    public async Task ReturnsProgramNotFoundWhenProgramDoesNotExist()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RefreshProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        RuvarrResult result = await sut.Handle(new RefreshProgramCommand(999), CancellationToken.None);
+
+        // Assert
+        result.Error.ShouldBe(ProgramErrors.ProgramNotFound);
+        _tvdbEpisodeLookupNotifier.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DoesNotEnqueueWhenProgramHasNoSeries()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithMultipleEpisodes().Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+        RefreshProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
+
+        // Assert
+        _tvdbEpisodeLookupNotifier.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DoesNotEnqueueWhenProgramHasSingleEpisode()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        TvdbSeries series = new TvdbSeriesBuilder().Build();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithMultipleEpisodes(false).Build();
+        program.MatchTvdb(series);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+        RefreshProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
+
+        // Assert
+        _tvdbEpisodeLookupNotifier.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task EnqueuesWhenProgramHasSeriesAndMultipleEpisodes()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        TvdbSeries series = new TvdbSeriesBuilder().Build();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithMultipleEpisodes().Build();
+        program.TryAddEpisode("ep0001", new Uri("http://test.com"), "Þáttur 1", "", DateTime.UtcNow);
+        program.MatchTvdb(series);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+
+        int episodeLookupCountBefore = program.Episodes[0].LookupCount;
+        DateTime? episodeNextLookupBefore = program.Episodes[0].NextLookup;
+
+        RefreshProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
+
+        // Assert
+        _tvdbEpisodeLookupNotifier.Items.ShouldNotBeEmpty();
+        program.Episodes[0].LookupCount.ShouldBe(episodeLookupCountBefore);
+        program.Episodes[0].NextLookup.ShouldBe(episodeNextLookupBefore);
+    }
+}


### PR DESCRIPTION
## Summary

When the refresh button is pressed on a program that is matched to a TVDB series and has multiple episodes, the program is now immediately enqueued into `TvdbEpisodeLookupNotifier`, bypassing the exponential backoff gate. Previously, episodes with a future `NextLookup` would not be re-looked up until their scheduled time (up to 7 days away).

Closes #81

## Changes

- `RefreshProgramHandler`: inject `TvdbEpisodeLookupNotifier`, include `Series` navigation property in query, enqueue conditionally on `Series is not null && HasMultipleEpisodes`
- New unit tests covering all four cases: program not found, no series match, single-episode program, and the happy path

## Test plan

- [ ] All 251 unit tests pass
- [ ] Press refresh on a program with a TVDB series match and unmatched episodes with a future `NextLookup` — verify TVDB episode lookup runs immediately
- [ ] Press refresh on a program with no TVDB series match — verify no lookup is triggered