### PR TITLE
Press Enter in MatchEpisodeDialog to trigger match when button is enabled

### DIFF
--- a/src/Ruvarr.Blazor/Programs/MatchEpisodeDialog.razor
+++ b/src/Ruvarr.Blazor/Programs/MatchEpisodeDialog.razor
@@ -5,7 +5,7 @@
     <h2>Match to TVDB</h2>
     <label>
         TVDB Episode ID
-        <input type="number" min="1" @bind="_tvdbIdInput" @bind:event="oninput" />
+        <input type="number" min="1" @bind="_tvdbIdInput" @bind:event="oninput" @onkeydown="HandleKeyDown" />
     </label>
     <div class="dialog-actions">
         <button class="dialog-button dialog-button--primary" @onclick="SubmitMatch" disabled="@IsMatchDisabled(_tvdbIdInput, _currentTvdbId, _isSubmitting)">
@@ -53,12 +53,19 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
     private async Task SubmitMatch()
     {
-        if (_ruvId is null || !int.TryParse(_tvdbIdInput, out int tvdbId) || tvdbId <= 0)
+        if (_isSubmitting)
         {
             return;
         }
 
         _isSubmitting = true;
+
+        if (_ruvId is null || !int.TryParse(_tvdbIdInput, out int tvdbId) || tvdbId <= 0)
+        {
+            _isSubmitting = false;
+            return;
+        }
+
         try
         {
             await ApiClient.MatchEpisodeAsync(_ruvId, tvdbId);
@@ -69,6 +76,15 @@
         }
         await CloseAsync();
         await OnMatchComplete.InvokeAsync();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onkeydown")]
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" && !IsMatchDisabled(_tvdbIdInput, _currentTvdbId, _isSubmitting))
+        {
+            await SubmitMatch();
+        }
     }
 
     internal static bool IsMatchDisabled(string input, int? currentTvdbId, bool isSubmitting)

--- a/tests/Ruvarr.Blazor.Tests/Programs/MatchEpisodeDialogTests/HandleKeyDown.cs
+++ b/tests/Ruvarr.Blazor.Tests/Programs/MatchEpisodeDialogTests/HandleKeyDown.cs
@@ -1,0 +1,135 @@
+using System.Net;
+
+using Bunit;
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
+
+using NSubstitute;
+
+using Ruvarr.Blazor.Programs;
+
+using Shouldly;
+
+namespace Ruvarr.Blazor.Tests.Programs.MatchEpisodeDialogTests;
+
+public sealed class HandleKeyDown : BunitContext
+{
+    private readonly MockHttpMessageHandler _httpHandler = new();
+    private readonly HttpClient _httpClient;
+
+    public HandleKeyDown()
+    {
+        _httpClient = new HttpClient(_httpHandler) { BaseAddress = new Uri("http://localhost") };
+        Services.AddSingleton(new RuvApiClient(_httpClient));
+        Services.AddSingleton(Substitute.For<IJSRuntime>());
+    }
+
+    [Fact]
+    public async Task EnterKey_WhenMatchEnabled_InvokesSubmitMatch()
+    {
+        // Arrange
+        _httpHandler.RespondWith(HttpStatusCode.OK);
+        IRenderedComponent<MatchEpisodeDialog> cut = Render<MatchEpisodeDialog>();
+        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: null);
+        await cut.Find("input").InputAsync(new ChangeEventArgs { Value = "99999" });
+
+        // Act
+        await cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert
+        _httpHandler.RequestCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task EnterKey_WhenInputIsEmpty_DoesNotInvokeSubmitMatch()
+    {
+        // Arrange
+        IRenderedComponent<MatchEpisodeDialog> cut = Render<MatchEpisodeDialog>();
+        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: null);
+
+        // Act
+        await cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert
+        _httpHandler.RequestCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task EnterKey_WhenInputUnchangedFromCurrentMatch_DoesNotInvokeSubmitMatch()
+    {
+        // Arrange
+        IRenderedComponent<MatchEpisodeDialog> cut = Render<MatchEpisodeDialog>();
+        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: 12345);
+
+        // Act
+        await cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert
+        _httpHandler.RequestCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task TwoRapidEnterKeys_OnlyInvokeSubmitMatchOnce()
+    {
+        // Arrange
+        TaskCompletionSource<HttpResponseMessage> tcs = new();
+        _httpHandler.RespondWith(tcs.Task);
+        IRenderedComponent<MatchEpisodeDialog> cut = Render<MatchEpisodeDialog>();
+        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: null);
+        await cut.Find("input").InputAsync(new ChangeEventArgs { Value = "99999" });
+
+        // Act — fire two Enter presses before the first HTTP response completes
+        Task first = cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        Task second = cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        using HttpResponseMessage pendingResponse = new(HttpStatusCode.OK);
+        tcs.SetResult(pendingResponse);
+        await Task.WhenAll(first, second);
+
+        // Assert
+        _httpHandler.RequestCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task OtherKey_DoesNotInvokeSubmitMatch()
+    {
+        // Arrange
+        IRenderedComponent<MatchEpisodeDialog> cut = Render<MatchEpisodeDialog>();
+        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: null);
+        await cut.Find("input").InputAsync(new ChangeEventArgs { Value = "99999" });
+
+        // Act
+        await cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "a" });
+
+        // Assert
+        _httpHandler.RequestCount.ShouldBe(0);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _httpClient.Dispose();
+            _httpHandler.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}
+
+internal sealed class MockHttpMessageHandler : HttpMessageHandler
+{
+    private Task<HttpResponseMessage> _response = Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+    public int RequestCount { get; private set; }
+
+    public void RespondWith(HttpStatusCode statusCode) =>
+        _response = Task.FromResult(new HttpResponseMessage(statusCode));
+
+    public void RespondWith(Task<HttpResponseMessage> response) => _response = response;
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        RequestCount++;
+        return await _response;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `@onkeydown="HandleKeyDown"` to the TVDB ID input in `MatchEpisodeDialog`
- Pressing Enter submits the match when the button would be enabled, doing nothing otherwise
- Fixes a double-submission race by adding an explicit re-entrancy guard at the top of `SubmitMatch`

## Test plan
- [ ] `EnterKey_WhenMatchEnabled_InvokesSubmitMatch` — Enter with valid new value calls the API
- [ ] `EnterKey_WhenInputIsEmpty_DoesNotInvokeSubmitMatch`
- [ ] `EnterKey_WhenInputUnchangedFromCurrentMatch_DoesNotInvokeSubmitMatch`
- [ ] `OtherKey_DoesNotInvokeSubmitMatch`
- [ ] `TwoRapidEnterKeys_OnlyInvokeSubmitMatchOnce` — covers the re-entrancy fix

Closes #87