### PR TITLE
Reorganise src/Ruvarr into vertical feature slices

### DIFF
--- a/src/Ruvarr/Downloads/Components/DownloadQueue.razor
+++ b/src/Ruvarr/Downloads/Components/DownloadQueue.razor
@@ -1,8 +1,9 @@
 @page "/download-queue"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
+@namespace Ruvarr.Downloads.Components
 @using Ruvarr.Abstractions
 @using Ruvarr.Contracts
-@using Ruvarr.Downloads
+@using Ruvarr.Downloads.Notifiers
 @using Ruvarr.Downloads.Queries.GetDownloadQueue
 @inject IServiceScopeFactory ScopeFactory
 @inject DownloadQueueNotifier DownloadNotifier

--- a/src/Ruvarr/Downloads/Extensions/DbContextExtensions.cs
+++ b/src/Ruvarr/Downloads/Extensions/DbContextExtensions.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 
 using Ruvarr.Downloads.Domain;
 using Ruvarr.Programs.Domain;
 
-namespace Ruvarr.Downloads;
+namespace Ruvarr.Downloads.Extensions;
 
 internal static class DbContextExtensions
 {

--- a/src/Ruvarr/Downloads/Notifiers/DownloadQueueNotifier.cs
+++ b/src/Ruvarr/Downloads/Notifiers/DownloadQueueNotifier.cs
@@ -1,7 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 
-namespace Ruvarr.Downloads;
+namespace Ruvarr.Downloads.Notifiers;
 
 public sealed class DownloadQueueNotifier
 {

--- a/src/Ruvarr/Downloads/Queries/GetDownloadQueueEndpoint.cs
+++ b/src/Ruvarr/Downloads/Queries/GetDownloadQueueEndpoint.cs
@@ -4,7 +4,7 @@ using Ruvarr.Abstractions;
 using Ruvarr.Contracts;
 using Ruvarr.Downloads.Queries.GetDownloadQueue;
 
-namespace Ruvarr.Programs.Queries;
+namespace Ruvarr.Downloads.Queries;
 
 internal static class GetDownloadQueueEndpoint
 {

--- a/src/Ruvarr/Downloads/ServiceCollectionExtensions.cs
+++ b/src/Ruvarr/Downloads/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Ruvarr.Abstractions;
 using Ruvarr.Contracts;
+using Ruvarr.Downloads.Notifiers;
 using Ruvarr.Downloads.Queries.GetDownloadQueue;
 using Ruvarr.Programs.Events;
 

--- a/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
+++ b/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
@@ -5,8 +5,8 @@ using Microsoft.Extensions.Options;
 using Quartz;
 
 using Ruvarr.Contracts;
-using Ruvarr.Downloads;
 using Ruvarr.Downloads.Domain;
+using Ruvarr.Downloads.Notifiers;
 using Ruvarr.Infrastructure.FFmpeg;
 using Ruvarr.Infrastructure.Sonarr;
 using Ruvarr.Infrastructure.Sonarr.Models;

--- a/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
+++ b/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
@@ -8,8 +8,9 @@ using Ruvarr.Infrastructure.Ruv;
 using Ruvarr.Infrastructure.Ruv.Models;
 using Ruvarr.Infrastructure.Sonarr;
 using Ruvarr.Infrastructure.Sonarr.Models;
-using Ruvarr.Programs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
 using Ruvarr.Programs.Domain;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 
 namespace Ruvarr.Jobs;
 

--- a/src/Ruvarr/Jobs/RuvProgramRefreshJob.cs
+++ b/src/Ruvarr/Jobs/RuvProgramRefreshJob.cs
@@ -5,8 +5,9 @@ using Quartz;
 
 using Ruvarr.Infrastructure.Ruv;
 using Ruvarr.Infrastructure.Ruv.Models;
-using Ruvarr.Programs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
 using Ruvarr.Programs.Domain;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 
 namespace Ruvarr.Jobs;
 

--- a/src/Ruvarr/ProgramRefreshQueue/Components/ProgramRefreshQueue.razor
+++ b/src/Ruvarr/ProgramRefreshQueue/Components/ProgramRefreshQueue.razor
@@ -1,11 +1,12 @@
-@page "/tvdb-series-lookup-queue"
+@page "/program-refresh-queue"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
+@namespace Ruvarr.ProgramRefreshQueue.Components
 @using Ruvarr.Contracts
-@using Ruvarr.Programs
-@inject TvdbSeriesLookupNotifier LookupNotifier
+@using Ruvarr.ProgramRefreshQueue.Notifiers
+@inject ProgramRefreshNotifier RefreshNotifier
 @implements IAsyncDisposable
 
-<h1>TVDB Series Lookup Queue</h1>
+<h1>Program Refresh Queue</h1>
 
 @if (_items is null)
 {
@@ -13,7 +14,7 @@
 }
 else if (_items.Count == 0)
 {
-    <p>No programs pending TVDB series lookup.</p>
+    <p>No programs pending refresh.</p>
 }
 else
 {
@@ -25,20 +26,20 @@ else
             </tr>
         </thead>
         <tbody>
-            @foreach (TvdbSeriesLookupQueueItemSummary item in _items.OrderByDescending(x => x.Status))
+            @foreach (ProgramRefreshQueueItemSummary item in _items.OrderByDescending(x => x.Status))
             {
                 <tr>
                     <td>@item.ProgramName</td>
                     <td class="queue-status queue-status--@item.Status.ToString().ToLowerInvariant()">
                         @switch (item.Status)
                         {
-                            case TvdbSeriesLookupStatus.Pending:
+                            case ProgramRefreshStatus.Pending:
                                 <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Pending">
                                     <circle cx="12" cy="12" r="10" />
                                     <polyline points="12 6 12 12 16 14" />
                                 </svg>
                                 break;
-                            case TvdbSeriesLookupStatus.Processing:
+                            case ProgramRefreshStatus.Processing:
                                 <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Processing">
                                     <path d="M21 12a9 9 0 1 1-6.219-8.56" />
                                 </svg>
@@ -52,7 +53,7 @@ else
 }
 
 @code {
-    private IReadOnlyList<TvdbSeriesLookupQueueItemSummary>? _items;
+    private IReadOnlyList<ProgramRefreshQueueItemSummary>? _items;
     private readonly CancellationTokenSource _cts = new();
 
     protected override Task OnInitializedAsync()
@@ -63,12 +64,12 @@ else
 
     private async Task WatchAsync()
     {
-        _items = LookupNotifier.Items;
+        _items = RefreshNotifier.Items;
         await InvokeAsync(StateHasChanged);
 
-        await foreach (byte _ in LookupNotifier.WatchAsync(_cts.Token))
+        await foreach (byte _ in RefreshNotifier.WatchAsync(_cts.Token))
         {
-            _items = LookupNotifier.Items;
+            _items = RefreshNotifier.Items;
             await InvokeAsync(StateHasChanged);
         }
     }

--- a/src/Ruvarr/ProgramRefreshQueue/Notifiers/ProgramRefreshNotifier.cs
+++ b/src/Ruvarr/ProgramRefreshQueue/Notifiers/ProgramRefreshNotifier.cs
@@ -1,7 +1,7 @@
 using Ruvarr.Abstractions;
 using Ruvarr.Contracts;
 
-namespace Ruvarr.Programs;
+namespace Ruvarr.ProgramRefreshQueue.Notifiers;
 
 public sealed class ProgramRefreshNotifier : QueueNotifier<ProgramRefreshQueueItemSummary>
 {

--- a/src/Ruvarr/Programs/Commands/DownloadEpisode/DownloadEpisodeHandler.cs
+++ b/src/Ruvarr/Programs/Commands/DownloadEpisode/DownloadEpisodeHandler.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
 using Ruvarr.Abstractions;
-using Ruvarr.Downloads;
+using Ruvarr.Downloads.Extensions;
 using Ruvarr.Programs.Domain;
 
 namespace Ruvarr.Programs.Commands.DownloadEpisode;

--- a/src/Ruvarr/Programs/Commands/RefreshProgram/RefreshProgramHandler.cs
+++ b/src/Ruvarr/Programs/Commands/RefreshProgram/RefreshProgramHandler.cs
@@ -1,7 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 
 using Ruvarr.Abstractions;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
 using Ruvarr.Programs.Domain;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 
 namespace Ruvarr.Programs.Commands.RefreshProgram;
 

--- a/src/Ruvarr/Programs/ProgramDetail.razor
+++ b/src/Ruvarr/Programs/ProgramDetail.razor
@@ -3,8 +3,9 @@
 @implements IAsyncDisposable
 @using Ruvarr.Abstractions
 @using Ruvarr.Contracts
-@using Ruvarr.Downloads
+@using Ruvarr.Downloads.Notifiers
 @using Ruvarr.Downloads.Queries.GetDownloadQueue
+@using Ruvarr.ProgramRefreshQueue.Notifiers
 @using Ruvarr.Programs.Commands.DownloadEpisode
 @using Ruvarr.Programs.Commands.RefreshProgram
 @using Ruvarr.Programs.Queries.GetProgram

--- a/src/Ruvarr/Programs/ProgramEndpoints.cs
+++ b/src/Ruvarr/Programs/ProgramEndpoints.cs
@@ -1,3 +1,4 @@
+using Ruvarr.Downloads.Queries;
 using Ruvarr.Programs.Commands;
 using Ruvarr.Programs.Queries;
 

--- a/src/Ruvarr/Programs/Programs.razor
+++ b/src/Ruvarr/Programs/Programs.razor
@@ -4,6 +4,7 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Ruvarr.Abstractions
 @using Ruvarr.Contracts
+@using Ruvarr.ProgramRefreshQueue.Notifiers
 @using Ruvarr.Programs.Commands.RefreshProgram
 @using Ruvarr.Programs.Queries.GetPrograms
 @inject IServiceScopeFactory ScopeFactory

--- a/src/Ruvarr/ServiceCollectionExtensions.cs
+++ b/src/Ruvarr/ServiceCollectionExtensions.cs
@@ -5,11 +5,16 @@ using Quartz;
 
 using Ruvarr.Downloads;
 using Ruvarr.Infrastructure.FFmpeg;
+using Ruvarr.Programs;
 using Ruvarr.Infrastructure.Ruv;
 using Ruvarr.Infrastructure.Sonarr;
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Jobs;
-using Ruvarr.Programs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
+using Ruvarr.TvdbEpisodeLookup.Jobs;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
+using Ruvarr.TvdbSeriesLookup.Jobs;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 
 using TMDbLib.Client;
 

--- a/src/Ruvarr/TvdbEpisodeLookup/Components/TvdbEpisodeLookupQueue.razor
+++ b/src/Ruvarr/TvdbEpisodeLookup/Components/TvdbEpisodeLookupQueue.razor
@@ -1,7 +1,8 @@
 @page "/tvdb-episode-lookup-queue"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
+@namespace Ruvarr.TvdbEpisodeLookup.Components
 @using Ruvarr.Contracts
-@using Ruvarr.Programs
+@using Ruvarr.TvdbEpisodeLookup.Notifiers
 @inject TvdbEpisodeLookupNotifier LookupNotifier
 @implements IAsyncDisposable
 

--- a/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
+++ b/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
@@ -6,10 +6,10 @@ using Ruvarr.Infrastructure.Sonarr;
 using Ruvarr.Infrastructure.Sonarr.Models;
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
-using Ruvarr.Programs;
 using Ruvarr.Programs.Domain;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 
-namespace Ruvarr.Jobs;
+namespace Ruvarr.TvdbEpisodeLookup.Jobs;
 
 [DisallowConcurrentExecution]
 internal sealed class TvdbEpisodeLookupJob(

--- a/src/Ruvarr/TvdbEpisodeLookup/Notifiers/TvdbEpisodeLookupNotifier.cs
+++ b/src/Ruvarr/TvdbEpisodeLookup/Notifiers/TvdbEpisodeLookupNotifier.cs
@@ -1,7 +1,7 @@
 using Ruvarr.Abstractions;
 using Ruvarr.Contracts;
 
-namespace Ruvarr.Programs;
+namespace Ruvarr.TvdbEpisodeLookup.Notifiers;
 
 public sealed class TvdbEpisodeLookupNotifier : QueueNotifier<TvdbEpisodeLookupQueueItemSummary>
 {

--- a/src/Ruvarr/TvdbSeriesLookup/Components/TvdbSeriesLookupQueue.razor
+++ b/src/Ruvarr/TvdbSeriesLookup/Components/TvdbSeriesLookupQueue.razor
@@ -1,11 +1,12 @@
-@page "/program-refresh-queue"
+@page "/tvdb-series-lookup-queue"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
+@namespace Ruvarr.TvdbSeriesLookup.Components
 @using Ruvarr.Contracts
-@using Ruvarr.Programs
-@inject ProgramRefreshNotifier RefreshNotifier
+@using Ruvarr.TvdbSeriesLookup.Notifiers
+@inject TvdbSeriesLookupNotifier LookupNotifier
 @implements IAsyncDisposable
 
-<h1>Program Refresh Queue</h1>
+<h1>TVDB Series Lookup Queue</h1>
 
 @if (_items is null)
 {
@@ -13,7 +14,7 @@
 }
 else if (_items.Count == 0)
 {
-    <p>No programs pending refresh.</p>
+    <p>No programs pending TVDB series lookup.</p>
 }
 else
 {
@@ -25,20 +26,20 @@ else
             </tr>
         </thead>
         <tbody>
-            @foreach (ProgramRefreshQueueItemSummary item in _items.OrderByDescending(x => x.Status))
+            @foreach (TvdbSeriesLookupQueueItemSummary item in _items.OrderByDescending(x => x.Status))
             {
                 <tr>
                     <td>@item.ProgramName</td>
                     <td class="queue-status queue-status--@item.Status.ToString().ToLowerInvariant()">
                         @switch (item.Status)
                         {
-                            case ProgramRefreshStatus.Pending:
+                            case TvdbSeriesLookupStatus.Pending:
                                 <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Pending">
                                     <circle cx="12" cy="12" r="10" />
                                     <polyline points="12 6 12 12 16 14" />
                                 </svg>
                                 break;
-                            case ProgramRefreshStatus.Processing:
+                            case TvdbSeriesLookupStatus.Processing:
                                 <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Processing">
                                     <path d="M21 12a9 9 0 1 1-6.219-8.56" />
                                 </svg>
@@ -52,7 +53,7 @@ else
 }
 
 @code {
-    private IReadOnlyList<ProgramRefreshQueueItemSummary>? _items;
+    private IReadOnlyList<TvdbSeriesLookupQueueItemSummary>? _items;
     private readonly CancellationTokenSource _cts = new();
 
     protected override Task OnInitializedAsync()
@@ -63,12 +64,12 @@ else
 
     private async Task WatchAsync()
     {
-        _items = RefreshNotifier.Items;
+        _items = LookupNotifier.Items;
         await InvokeAsync(StateHasChanged);
 
-        await foreach (byte _ in RefreshNotifier.WatchAsync(_cts.Token))
+        await foreach (byte _ in LookupNotifier.WatchAsync(_cts.Token))
         {
-            _items = RefreshNotifier.Items;
+            _items = LookupNotifier.Items;
             await InvokeAsync(StateHasChanged);
         }
     }

--- a/src/Ruvarr/TvdbSeriesLookup/Jobs/TvdbSeriesLookupJob.cs
+++ b/src/Ruvarr/TvdbSeriesLookup/Jobs/TvdbSeriesLookupJob.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -7,10 +7,11 @@ using Quartz;
 using Ruvarr.Extensions;
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
-using Ruvarr.Programs;
 using Ruvarr.Programs.Domain;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 
-namespace Ruvarr.Jobs;
+namespace Ruvarr.TvdbSeriesLookup.Jobs;
 
 [DisallowConcurrentExecution]
 internal sealed class TvdbSeriesLookupJob(

--- a/src/Ruvarr/TvdbSeriesLookup/Notifiers/TvdbSeriesLookupNotifier.cs
+++ b/src/Ruvarr/TvdbSeriesLookup/Notifiers/TvdbSeriesLookupNotifier.cs
@@ -1,7 +1,7 @@
 using Ruvarr.Abstractions;
 using Ruvarr.Contracts;
 
-namespace Ruvarr.Programs;
+namespace Ruvarr.TvdbSeriesLookup.Notifiers;
 
 public sealed class TvdbSeriesLookupNotifier : QueueNotifier<TvdbSeriesLookupQueueItemSummary>
 {

--- a/src/Ruvarr/UnmatchedEpisodes/Components/UnmatchedEpisodes.razor
+++ b/src/Ruvarr/UnmatchedEpisodes/Components/UnmatchedEpisodes.razor
@@ -1,4 +1,5 @@
 @page "/unmatched-episodes"
+@namespace Ruvarr.UnmatchedEpisodes.Components
 @inject NavigationManager Navigation
 
 @code {

--- a/tests/Ruvarr.IntegrationTests/Downloads/EpisodeMissingEventHandlerTests.cs
+++ b/tests/Ruvarr.IntegrationTests/Downloads/EpisodeMissingEventHandlerTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
-using Ruvarr.Downloads;
+using Ruvarr.Downloads.Extensions;
 using Ruvarr.Programs.Domain;
 
 using Shouldly;

--- a/tests/Ruvarr.IntegrationTests/Programs/Episodes/Commands/DownloadEpisodeTests.cs
+++ b/tests/Ruvarr.IntegrationTests/Programs/Episodes/Commands/DownloadEpisodeTests.cs
@@ -3,8 +3,8 @@ using System.Net;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
-using Ruvarr.Downloads;
 using Ruvarr.Downloads.Domain;
+using Ruvarr.Downloads.Extensions;
 using Ruvarr.Programs.Domain;
 
 using Shouldly;

--- a/tests/Ruvarr.IntegrationTests/Programs/Episodes/Queries/GetDownloadQueueTests.cs
+++ b/tests/Ruvarr.IntegrationTests/Programs/Episodes/Queries/GetDownloadQueueTests.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 using Ruvarr.Contracts;
-using Ruvarr.Downloads;
+using Ruvarr.Downloads.Extensions;
 using Ruvarr.Programs.Domain;
 
 using Shouldly;

--- a/tests/Ruvarr.UnitTests/Jobs/RuvProgramRefreshJobTests/SlugRefreshEnqueue.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/RuvProgramRefreshJobTests/SlugRefreshEnqueue.cs
@@ -7,8 +7,9 @@ using NSubstitute;
 using Ruvarr.Infrastructure.Ruv;
 using Ruvarr.Infrastructure.Ruv.Models;
 using Ruvarr.Jobs;
-using Ruvarr.Programs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
 using Ruvarr.Programs.Domain;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 using Ruvarr.Testing.Builders;
 
 using Shouldly;

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/EarlyReturns.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/EarlyReturns.cs
@@ -6,8 +6,8 @@ using NSubstitute;
 using Ruvarr.Infrastructure.Sonarr;
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
-using Ruvarr.Jobs;
-using Ruvarr.Programs;
+using Ruvarr.TvdbEpisodeLookup.Jobs;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 using Ruvarr.Programs.Domain;
 using Ruvarr.Testing.Builders;
 

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/SeasonFallback.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/SeasonFallback.cs
@@ -6,8 +6,8 @@ using NSubstitute;
 using Ruvarr.Infrastructure.Sonarr;
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
-using Ruvarr.Jobs;
-using Ruvarr.Programs;
+using Ruvarr.TvdbEpisodeLookup.Jobs;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 using Ruvarr.Programs.Domain;
 using Ruvarr.Testing.Builders;
 

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/TitleMatching.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/TitleMatching.cs
@@ -7,8 +7,8 @@ using Ruvarr.Infrastructure.Sonarr;
 using Ruvarr.Infrastructure.Sonarr.Models;
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
-using Ruvarr.Jobs;
-using Ruvarr.Programs;
+using Ruvarr.TvdbEpisodeLookup.Jobs;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 using Ruvarr.Programs.Domain;
 using Ruvarr.Testing.Builders;
 

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbSeriesLookupJobTests/SlugRefresh.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbSeriesLookupJobTests/SlugRefresh.cs
@@ -7,8 +7,9 @@ using Quartz;
 
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
-using Ruvarr.Jobs;
-using Ruvarr.Programs;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
+using Ruvarr.TvdbSeriesLookup.Jobs;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 using Ruvarr.Programs.Domain;
 using Ruvarr.Testing.Builders;
 

--- a/tests/Ruvarr.UnitTests/Programs/Commands/RefreshProgramHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Commands/RefreshProgramHandlerTests/Handle.cs
@@ -3,9 +3,11 @@ using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 
 using Ruvarr.Abstractions;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
 using Ruvarr.Programs;
 using Ruvarr.Programs.Commands.RefreshProgram;
 using Ruvarr.Programs.Domain;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 using Ruvarr.Testing.Builders;
 
 using Shouldly;

--- a/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/DequeueAll.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/DequeueAll.cs
@@ -1,4 +1,4 @@
-using Ruvarr.Programs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/Enqueue.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/Enqueue.cs
@@ -1,4 +1,4 @@
-using Ruvarr.Programs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/Items.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/Items.cs
@@ -1,5 +1,5 @@
 using Ruvarr.Contracts;
-using Ruvarr.Programs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/MarkComplete.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/MarkComplete.cs
@@ -1,4 +1,4 @@
-using Ruvarr.Programs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/MarkProcessing.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/MarkProcessing.cs
@@ -1,5 +1,5 @@
 using Ruvarr.Contracts;
-using Ruvarr.Programs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/Enqueue.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/Enqueue.cs
@@ -1,4 +1,4 @@
-using Ruvarr.Programs;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/Items.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/Items.cs
@@ -1,5 +1,5 @@
 using Ruvarr.Contracts;
-using Ruvarr.Programs;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/MarkComplete.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/MarkComplete.cs
@@ -1,4 +1,4 @@
-using Ruvarr.Programs;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/MarkProcessing.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/MarkProcessing.cs
@@ -1,5 +1,5 @@
 using Ruvarr.Contracts;
-using Ruvarr.Programs;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/TryDequeue.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/TryDequeue.cs
@@ -1,4 +1,4 @@
-using Ruvarr.Programs;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/Enqueue.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/Enqueue.cs
@@ -1,4 +1,4 @@
-using Ruvarr.Programs;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/Items.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/Items.cs
@@ -1,5 +1,5 @@
 using Ruvarr.Contracts;
-using Ruvarr.Programs;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/MarkComplete.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/MarkComplete.cs
@@ -1,4 +1,4 @@
-using Ruvarr.Programs;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/MarkProcessing.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/MarkProcessing.cs
@@ -1,5 +1,5 @@
 using Ruvarr.Contracts;
-using Ruvarr.Programs;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 
 using Shouldly;
 

--- a/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/TryDequeue.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/TryDequeue.cs
@@ -1,4 +1,4 @@
-using Ruvarr.Programs;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 
 using Shouldly;
 


### PR DESCRIPTION
## Summary
- Moves files from layer-based folders into vertical feature slices: `Downloads/`, `TvdbSeriesLookup/`, `TvdbEpisodeLookup/`, `ProgramRefreshQueue/`, `UnmatchedEpisodes/`
- Each slice contains only applicable sub-folders: `Commands/`, `Queries/`, `Components/`, `Notifiers/`, `Extensions/`, `Jobs/`
- Updates all namespaces and `using` directives throughout — no logic changes

Closes #102