### PR TITLE
feat(programs): replace tab-strip filter bar with multi-select checkboxes

### DIFF
--- a/src/Ruvarr/Programs/Programs.razor
+++ b/src/Ruvarr/Programs/Programs.razor
@@ -9,16 +9,39 @@
 @using Ruvarr.Programs.Queries.GetPrograms
 @inject IServiceScopeFactory ScopeFactory
 @inject ProgramRefreshNotifier RefreshNotifier
-@inject NavigationManager Navigation
 
 <h1>Programs</h1>
 
-<div class="filter-bar">
-    <button class="filter-button @(Filter is null or "" ? "filter-button--active" : "")" @onclick='() => NavigateTo("")'>All</button>
-    <button class="filter-button @(Filter == "unmatched-programs" ? "filter-button--active" : "")" @onclick='() => NavigateTo("unmatched-programs")'>Unmatched Programs</button>
-    <button class="filter-button @(Filter == "unmatched-episodes" ? "filter-button--active" : "")" @onclick='() => NavigateTo("unmatched-episodes")'>Unmatched Episodes</button>
-    <button class="filter-button @(Filter == "missing-from-sonarr" ? "filter-button--active" : "")" @onclick='() => NavigateTo("missing-from-sonarr")'>Missing from Sonarr</button>
-    <button class="filter-button @(Filter == "partially-matched" ? "filter-button--active" : "")" @onclick='() => NavigateTo("partially-matched")'>Partially Matched</button>
+<div class="filter-panel">
+    <label class="filter-chip @(_filterUnmatchedPrograms ? "filter-chip--active" : "")">
+        <input type="checkbox" @bind="_filterUnmatchedPrograms" @bind:after="LoadProgramsAsync" />
+        Unmatched Programs
+    </label>
+    <label class="filter-chip @(_filterUnmatchedEpisodes ? "filter-chip--active" : "")">
+        <input type="checkbox" @bind="_filterUnmatchedEpisodes" @bind:after="LoadProgramsAsync" />
+        Unmatched Episodes
+    </label>
+    <label class="filter-chip @(_filterMissingFromSonarr ? "filter-chip--active" : "")">
+        <input type="checkbox" @bind="_filterMissingFromSonarr" @bind:after="LoadProgramsAsync" />
+        Missing from Sonarr
+    </label>
+    <label class="filter-chip @(_filterPartiallyMatched ? "filter-chip--active" : "")">
+        <input type="checkbox" @bind="_filterPartiallyMatched" @bind:after="LoadProgramsAsync" />
+        Partially Matched
+    </label>
+    <label class="filter-chip @(_filterMonitored ? "filter-chip--active" : "")">
+        <input type="checkbox" @bind="_filterMonitored" @bind:after="LoadProgramsAsync" />
+        Monitored
+    </label>
+    <span class="filter-divider"></span>
+    <select class="filter-select" @bind="_filterChannel">
+        <option value="">All channels</option>
+        @foreach (string channel in _channels)
+        {
+            <option value="@channel">@channel</option>
+        }
+    </select>
+    <button class="filter-clear" @onclick="ClearFilters" disabled="@(!HasActiveFilters)">Clear filters</button>
 </div>
 
 <div class="search-bar">
@@ -31,13 +54,13 @@
 }
 else
 {
-    List<ProgramSummary> visibleList = string.IsNullOrWhiteSpace(_searchText)
-        ? [.. _programs]
-        : [.. _programs.Where(p => p.ProgramName.Contains(_searchText, StringComparison.OrdinalIgnoreCase))];
+    List<ProgramSummary> visibleList = [.. _programs
+        .Where(p => string.IsNullOrWhiteSpace(_searchText) || p.ProgramName.Contains(_searchText, StringComparison.OrdinalIgnoreCase))
+        .Where(p => string.IsNullOrEmpty(_filterChannel) || p.Channel == _filterChannel)];
 
     if (visibleList.Count == 0)
     {
-        <p class="empty-message">@GetEmptyMessage()</p>
+        <p class="empty-message">@(HasActiveFilters ? "No programs match the selected filters." : "No programs found.")</p>
     }
     else
     {
@@ -136,32 +159,30 @@ else
 }
 
 @code {
-    [Parameter]
-    [SupplyParameterFromQuery(Name = "filter")]
-    public string? Filter { get; set; }
+    private bool _filterUnmatchedPrograms;
+    private bool _filterUnmatchedEpisodes;
+    private bool _filterMissingFromSonarr;
+    private bool _filterPartiallyMatched;
+    private bool _filterMonitored;
+    private string _filterChannel = string.Empty;
+    private List<string> _channels = [];
+
+    private bool HasActiveFilters =>
+        _filterUnmatchedPrograms ||
+        _filterUnmatchedEpisodes ||
+        _filterMissingFromSonarr ||
+        _filterPartiallyMatched ||
+        _filterMonitored ||
+        !string.IsNullOrEmpty(_filterChannel);
 
     private List<ProgramSummary>? _programs;
-    private string? _loadedFilter;
     private string _searchText = string.Empty;
     private readonly HashSet<int> _pendingRefresh = [];
     private Dictionary<int, ProgramRefreshStatus> _refreshQueue = [];
     private readonly CancellationTokenSource _cts = new();
 
-    private static readonly HashSet<string> AllowedFilters =
-    [
-        "unmatched-programs",
-        "unmatched-episodes",
-        "missing-from-sonarr",
-        "partially-matched"
-    ];
-
     protected override Task OnInitializedAsync()
     {
-        if (Filter is not null && !AllowedFilters.Contains(Filter))
-        {
-            Filter = null;
-        }
-
         _ = WatchAsync();
         _ = LoadProgramsAsync();
         return Task.CompletedTask;
@@ -186,35 +207,44 @@ else
         _cts.Dispose();
     }
 
-    protected override async Task OnParametersSetAsync()
+    private async Task ClearFilters()
     {
-        if (Filter is not null && !AllowedFilters.Contains(Filter))
-        {
-            Filter = null;
-        }
-
-        if (_loadedFilter == Filter)
-        {
-            return;
-        }
-
-        _programs = null;
+        _filterUnmatchedPrograms = false;
+        _filterUnmatchedEpisodes = false;
+        _filterMissingFromSonarr = false;
+        _filterPartiallyMatched = false;
+        _filterMonitored = false;
+        _filterChannel = string.Empty;
         await LoadProgramsAsync();
     }
 
     private async Task LoadProgramsAsync()
     {
         _programs = null;
-        _loadedFilter = Filter;
         await InvokeAsync(StateHasChanged);
 
-        GetProgramsQuery query = Filter switch
+        bool? isProgramMatched = (_filterUnmatchedPrograms, _filterUnmatchedEpisodes) switch
         {
-            "unmatched-programs" => new GetProgramsQuery(null, null, null, IsProgramMatched: false, null),
-            "missing-from-sonarr" => new GetProgramsQuery(null, IsProgramMonitored: true, IsProgramMissingEpisodes: true, null, null),
-            "partially-matched" => new GetProgramsQuery(null, null, null, null, IsProgramPartiallyMatched: true),
-            _ => new GetProgramsQuery(null, null, null, null, null),
+            (true, false) => false,
+            (false, true) => true,
+            _ => null
         };
+
+        bool? isEpisodeMatched = _filterUnmatchedEpisodes ? false : null;
+
+        bool? isProgramMonitored = (_filterMonitored || _filterMissingFromSonarr) ? true : null;
+
+        bool? isProgramMissingEpisodes = _filterMissingFromSonarr ? true : null;
+
+        bool? isProgramPartiallyMatched = _filterPartiallyMatched ? true : null;
+
+        GetProgramsQuery query = new(
+            null,
+            isProgramMonitored,
+            isProgramMissingEpisodes,
+            isProgramMatched,
+            isProgramPartiallyMatched,
+            isEpisodeMatched);
 
         List<ProgramSummary> loaded = [];
         await using (AsyncServiceScope scope = ScopeFactory.CreateAsyncScope())
@@ -226,24 +256,17 @@ else
                 loaded.Add(program);
             }
         }
+
         _programs = loaded;
+        _channels = [.. _programs.Select(p => p.Channel).Distinct().Order()];
+
+        if (!string.IsNullOrEmpty(_filterChannel) && !_channels.Contains(_filterChannel))
+        {
+            _filterChannel = string.Empty;
+        }
+
         await InvokeAsync(StateHasChanged);
     }
-
-    private void NavigateTo(string filter)
-    {
-        string url = string.IsNullOrEmpty(filter) ? "/" : $"/?filter={Uri.EscapeDataString(filter)}";
-        Navigation.NavigateTo(url);
-    }
-
-    private string GetEmptyMessage() => Filter switch
-    {
-        "unmatched-programs" => "No unmatched programs found.",
-        "unmatched-episodes" => "No unmatched episodes found.",
-        "missing-from-sonarr" => "No programs with missing episodes found.",
-        "partially-matched" => "No partially matched programs found.",
-        _ => "No programs found.",
-    };
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
     private async Task RefreshProgram(int ruvId)

--- a/src/Ruvarr/Programs/Queries/GetProgramListEndpoint.cs
+++ b/src/Ruvarr/Programs/Queries/GetProgramListEndpoint.cs
@@ -17,6 +17,7 @@ internal static class GetProgramListEndpoint
             [FromQuery] bool? isProgramMissingEpisodes,
             [FromQuery] bool? isProgramMatched,
             [FromQuery] bool? isProgramPartiallyMatched,
+            [FromQuery] bool? isEpisodeMatched,
             CancellationToken cancellationToken) =>
         {
             GetProgramsQuery query = new(
@@ -24,7 +25,8 @@ internal static class GetProgramListEndpoint
                 IsProgramMonitored: isProgramMonitored,
                 IsProgramMissingEpisodes: isProgramMissingEpisodes,
                 IsProgramMatched: isProgramMatched,
-                IsProgramPartiallyMatched: isProgramPartiallyMatched);
+                IsProgramPartiallyMatched: isProgramPartiallyMatched,
+                IsEpisodeMatched: isEpisodeMatched);
 
             return handler.Handle(query, cancellationToken);
         })

--- a/src/Ruvarr/Programs/Queries/GetPrograms/GetProgramsHandler.cs
+++ b/src/Ruvarr/Programs/Queries/GetPrograms/GetProgramsHandler.cs
@@ -44,6 +44,11 @@ internal sealed class GetProgramsHandler(RuvarrDbContext dbContext) : IStreaming
                 x.Episodes.Any(e => e.TvdbId == null));
         }
 
+        if (request.IsEpisodeMatched is not null)
+        {
+            query = query.Where(x => x.Episodes.Any(e => (e.TvdbId == null) != request.IsEpisodeMatched));
+        }
+
         IAsyncEnumerable<ProgramSummary> results = query
             .OrderBy(x => x.Name)
             .Select(x => new

--- a/src/Ruvarr/Programs/Queries/GetPrograms/GetProgramsQuery.cs
+++ b/src/Ruvarr/Programs/Queries/GetPrograms/GetProgramsQuery.cs
@@ -5,4 +5,5 @@ public sealed record GetProgramsQuery(
     bool? IsProgramMonitored,
     bool? IsProgramMissingEpisodes,
     bool? IsProgramMatched,
-    bool? IsProgramPartiallyMatched);
+    bool? IsProgramPartiallyMatched,
+    bool? IsEpisodeMatched);

--- a/src/Ruvarr/UnmatchedEpisodes/Components/UnmatchedEpisodes.razor
+++ b/src/Ruvarr/UnmatchedEpisodes/Components/UnmatchedEpisodes.razor
@@ -5,6 +5,6 @@
 @code {
     protected override void OnInitialized()
     {
-        Navigation.NavigateTo("/?filter=unmatched-episodes", replace: true);
+        Navigation.NavigateTo("/", replace: true);
     }
 }

--- a/src/Ruvarr/wwwroot/app.css
+++ b/src/Ruvarr/wwwroot/app.css
@@ -263,35 +263,103 @@ tbody tr:hover {
 .queue-status--downloading { color: #60a5fa; }
 .queue-status--complete { color: #4ade80; }
 
-.filter-bar {
+.filter-panel {
     display: flex;
-    gap: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
     margin-bottom: 1rem;
 }
 
-.filter-button {
-    background: none;
-    border: none;
-    border-bottom: 2px solid transparent;
-    margin-bottom: -1px;
-    padding: 0.55rem 1rem;
-    color: rgba(255, 255, 255, 0.45);
-    font-size: 0.85rem;
+.filter-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.8rem;
     font-weight: 500;
     letter-spacing: 0.02em;
+    color: rgba(255, 255, 255, 0.45);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+    cursor: pointer;
+    user-select: none;
+    transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.filter-chip:hover {
+    color: rgba(255, 255, 255, 0.8);
+    background: rgba(255, 255, 255, 0.07);
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
+.filter-chip--active {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.35);
+}
+
+.filter-chip input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+    width: 0;
+    height: 0;
+}
+
+.filter-divider {
+    width: 1px;
+    height: 1.25rem;
+    background: rgba(255, 255, 255, 0.12);
+    flex-shrink: 0;
+}
+
+.filter-select {
+    background-color: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 4px;
+    color: rgba(255, 255, 255, 0.7);
+    padding: 0.35rem 1.75rem 0.35rem 0.6rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='rgba(255,255,255,0.4)' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.5rem center;
+    transition: border-color 0.15s ease;
+}
+
+.filter-select:focus {
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.35);
+}
+
+.filter-select option {
+    background-color: #2a2a2a;
+}
+
+.filter-clear {
+    margin-left: auto;
+    background: none;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 4px;
+    color: rgba(255, 255, 255, 0.4);
+    padding: 0.35rem 0.75rem;
+    font-size: 0.8rem;
     cursor: pointer;
     transition: color 0.15s ease, border-color 0.15s ease;
-    white-space: nowrap;
 }
 
-.filter-button:hover {
+.filter-clear:hover {
     color: rgba(255, 255, 255, 0.8);
+    border-color: rgba(255, 255, 255, 0.3);
 }
 
-.filter-button--active {
-    color: #fff;
-    border-bottom-color: #fff;
+.filter-clear:disabled {
+    opacity: 0.25;
+    cursor: not-allowed;
+    pointer-events: none;
 }
 
 .search-bar {

--- a/tests/Ruvarr.IntegrationTests/Programs/Queries/GetProgramsTests.cs
+++ b/tests/Ruvarr.IntegrationTests/Programs/Queries/GetProgramsTests.cs
@@ -137,6 +137,37 @@ public sealed class GetProgramsTests(IntegrationTestFactory factory) : IClassFix
     }
 
     [Fact]
+    public async Task FiltersByUnmatchedEpisodes()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+
+        RuvProgram withUnmatched = RuvProgram.Create(20030, "RÚV1", "Program With Unmatched Episodes", null, multipleEpisodes: true);
+        withUnmatched.MatchTvdb(TvdbSeries.Create(5001, "Some Series"));
+        dbContext.Set<RuvProgram>().Add(withUnmatched);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        withUnmatched.TryAddEpisode("WU-EP1", new Uri("https://example.com/wu-ep1.mp4"), "Episode 1", "Desc", DateTime.UtcNow);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        RuvProgram allMatched = RuvProgram.Create(20031, "RÚV1", "Program With All Matched Episodes", null, multipleEpisodes: true);
+        allMatched.MatchTvdb(TvdbSeries.Create(5002, "Other Series"));
+        dbContext.Set<RuvProgram>().Add(allMatched);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary>? result = await factory.CreateClient()
+            .GetFromJsonAsync<List<ProgramSummary>>("/programs?isEpisodeMatched=false", cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldContain(p => p.ProgramRuvId == 20030);
+        result.ShouldNotContain(p => p.ProgramRuvId == 20031);
+    }
+
+    [Fact]
     public async Task ReturnsTvdbUrlWhenSeriesHasSlug()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Replaces the tab-strip filter bar on the Programs page with multi-select checkboxes
- Updates `GetProgramsQuery` and handler to support multi-category filtering
- Adds tests for the updated `GetPrograms` query

## Test plan
- [ ] Programs page loads and displays checkboxes for each program category
- [ ] Selecting multiple checkboxes filters the program list to show programs matching any selected category
- [ ] Deselecting all checkboxes shows all programs
- [ ] Unit tests pass: `dotnet test --filter "FullyQualifiedName~GetProgramsTests"`

Closes #90