### PR TITLE
feat(programs): add manual TVDB series matching via dialog

### DIFF
--- a/src/Ruvarr/Contracts/ProgramSummary.cs
+++ b/src/Ruvarr/Contracts/ProgramSummary.cs
@@ -7,4 +7,5 @@ public sealed record ProgramSummary(
     bool IsMonitored,
     bool HasMissingEpisodes,
     string? SeriesName,
-    Uri? TvdbUrl);
+    Uri? TvdbUrl,
+    int? TvdbSeriesId);

--- a/src/Ruvarr/Programs/Commands/MatchProgram/MatchProgramCommand.cs
+++ b/src/Ruvarr/Programs/Commands/MatchProgram/MatchProgramCommand.cs
@@ -1,0 +1,3 @@
+namespace Ruvarr.Programs.Commands.MatchProgram;
+
+public sealed record MatchProgramCommand(int RuvId, int TvdbSeriesId);

--- a/src/Ruvarr/Programs/Commands/MatchProgram/MatchProgramHandler.cs
+++ b/src/Ruvarr/Programs/Commands/MatchProgram/MatchProgramHandler.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Infrastructure.Tvdb;
+using Ruvarr.Infrastructure.Tvdb.Models;
+using Ruvarr.Programs.Domain;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
+
+namespace Ruvarr.Programs.Commands.MatchProgram;
+
+internal sealed class MatchProgramHandler(
+    RuvarrDbContext dbContext,
+    ITvdbClient tvdb,
+    TvdbEpisodeLookupNotifier episodeLookupNotifier) : IRequestHandler<MatchProgramCommand>
+{
+    public async Task<RuvarrResult> Handle(MatchProgramCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (command.TvdbSeriesId is < 1 or > 10_000_000)
+        {
+            return ProgramErrors.TvdbSeriesIdOutOfRange;
+        }
+
+        RuvProgram? program = await dbContext.Set<RuvProgram>()
+            .Include(x => x.Series)
+            .Where(x => x.RuvId == command.RuvId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (program is null)
+        {
+            return ProgramErrors.ProgramNotFound;
+        }
+
+        SeriesData? seriesData = await tvdb.GetSeriesAsync(command.TvdbSeriesId, cancellationToken);
+        if (seriesData is null)
+        {
+            return TvdbErrors.SeriesNotFound;
+        }
+
+        TvdbSeries? entity = await dbContext
+            .Set<TvdbSeries>()
+            .Where(x => x.TvdbId == command.TvdbSeriesId)
+            .FirstOrDefaultAsync(cancellationToken)
+            ?? TvdbSeries.Create(command.TvdbSeriesId, seriesData.Series.Name, seriesData.Series.Slug);
+
+        entity.UpdateSlug(seriesData.Series.Slug);
+
+        program.MatchTvdb(entity);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        episodeLookupNotifier.Enqueue(program.RuvId, program.Name);
+
+        return RuvarrResult.Success;
+    }
+}

--- a/src/Ruvarr/Programs/MatchProgramDialog.razor
+++ b/src/Ruvarr/Programs/MatchProgramDialog.razor
@@ -1,0 +1,133 @@
+@namespace Ruvarr.Programs
+@using Ruvarr.Abstractions
+@using Ruvarr.Programs.Commands.MatchProgram
+@implements IAsyncDisposable
+@inject IServiceScopeFactory ScopeFactory
+@inject IJSRuntime Js
+
+<dialog @ref="_dialog" @onclose="OnDialogClose">
+    <h2>Match to TVDB</h2>
+    <label>
+        TVDB Series ID
+        <input type="number" min="1" @bind="_tvdbIdInput" @bind:event="oninput" @onkeydown="HandleKeyDown" />
+    </label>
+    @if (_errorMessage is not null)
+    {
+        <p class="dialog-error">@_errorMessage</p>
+    }
+    <div class="dialog-actions">
+        <button class="dialog-button dialog-button--primary" @onclick="SubmitMatch" disabled="@IsMatchDisabled(_tvdbIdInput, _currentTvdbSeriesId, _isSubmitting)">
+            @if (_isSubmitting)
+            {
+                <span class="button-spinner"></span>
+            }
+            Match
+        </button>
+        <button class="dialog-button" @onclick="CloseAsync" disabled="@_isSubmitting">Cancel</button>
+    </div>
+</dialog>
+
+@code {
+    [Parameter]
+    public EventCallback OnMatchComplete { get; set; }
+
+    private ElementReference _dialog;
+    private int? _ruvId;
+    private string _tvdbIdInput = string.Empty;
+    private int? _currentTvdbSeriesId;
+    private bool _isSubmitting;
+    private string? _errorMessage;
+    private readonly CancellationTokenSource _cts = new();
+
+    public async Task OpenAsync(int ruvId, int? currentTvdbSeriesId)
+    {
+        _ruvId = ruvId;
+        _currentTvdbSeriesId = currentTvdbSeriesId;
+        _tvdbIdInput = currentTvdbSeriesId?.ToString() ?? string.Empty;
+        _errorMessage = null;
+        await InvokeAsync(StateHasChanged);
+        await Js.InvokeVoidAsync("showDialog", _dialog);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
+    private async Task CloseAsync()
+    {
+        await Js.InvokeVoidAsync("closeDialog", _dialog);
+    }
+
+    private void OnDialogClose()
+    {
+        _ruvId = null;
+        _currentTvdbSeriesId = null;
+        _tvdbIdInput = string.Empty;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
+    private async Task SubmitMatch()
+    {
+        if (_isSubmitting)
+        {
+            return;
+        }
+
+        _isSubmitting = true;
+        _errorMessage = null;
+
+        if (_ruvId is null || !int.TryParse(_tvdbIdInput, out int tvdbSeriesId) || tvdbSeriesId <= 0)
+        {
+            _isSubmitting = false;
+            return;
+        }
+
+        try
+        {
+            await using AsyncServiceScope scope = ScopeFactory.CreateAsyncScope();
+            IRequestHandler<MatchProgramCommand> handler =
+                scope.ServiceProvider.GetRequiredService<IRequestHandler<MatchProgramCommand>>();
+            RuvarrResult result = await handler.Handle(new MatchProgramCommand(_ruvId.Value, tvdbSeriesId), _cts.Token);
+
+            if (!result.IsSuccess)
+            {
+                _errorMessage = result.Error.Description;
+                return;
+            }
+        }
+        finally
+        {
+            _isSubmitting = false;
+        }
+
+        await CloseAsync();
+        await OnMatchComplete.InvokeAsync();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onkeydown")]
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" && !IsMatchDisabled(_tvdbIdInput, _currentTvdbSeriesId, _isSubmitting))
+        {
+            await SubmitMatch();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cts.CancelAsync();
+        _cts.Dispose();
+    }
+
+    internal static bool IsMatchDisabled(string input, int? currentTvdbSeriesId, bool isSubmitting)
+    {
+        if (isSubmitting)
+        {
+            return true;
+        }
+
+        if (!int.TryParse(input, out int parsed) || parsed <= 0)
+        {
+            return true;
+        }
+
+        return parsed == currentTvdbSeriesId;
+    }
+}

--- a/src/Ruvarr/Programs/ProgramErrors.cs
+++ b/src/Ruvarr/Programs/ProgramErrors.cs
@@ -27,6 +27,10 @@ public static class ProgramErrors
         "Episodes.UnparsableTitle",
         "Episode titles must be on start with 'Þáttur' followed by an integer for them to be parsable.");
 
+    public static RuvarrError TvdbSeriesIdOutOfRange => new(
+        "Programs.TvdbSeriesIdOutOfRange",
+        "TVDB series ID must be between 1 and 10,000,000.");
+
     public static RuvarrError SeasonUndetermined => new(
         "Episodes.SeasonUndetermined",
         "TVDB has multiple seasons. Failed to determine which season the RÚV episodes are from.");

--- a/src/Ruvarr/Programs/Programs.razor
+++ b/src/Ruvarr/Programs/Programs.razor
@@ -5,6 +5,7 @@
 @using Ruvarr.Abstractions
 @using Ruvarr.Contracts
 @using Ruvarr.ProgramRefreshQueue.Notifiers
+@using Ruvarr.Programs.Commands.MatchProgram
 @using Ruvarr.Programs.Commands.RefreshProgram
 @using Ruvarr.Programs.Queries.GetPrograms
 @inject IServiceScopeFactory ScopeFactory
@@ -64,6 +65,7 @@ else
     }
     else
     {
+        <MatchProgramDialog @ref="_matchProgramDialog" OnMatchComplete="LoadProgramsAsync" />
         <table class="programs-table">
             <thead>
                 <tr>
@@ -123,6 +125,18 @@ else
                         </td>
                         <td>
                             <div class="row-actions">
+                                @if (program.TvdbSeriesId is null)
+                                {
+                                    <button class="icon-button" @onclick="() => OpenMatchProgramDialog(program)" title="Match to TVDB">
+                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+                                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                             aria-label="Match to TVDB">
+                                            <path d="M9 17H7A5 5 0 0 1 7 7h2" />
+                                            <path d="M15 7h2a5 5 0 1 1 0 10h-2" />
+                                            <line x1="8" y1="12" x2="16" y2="12" />
+                                        </svg>
+                                    </button>
+                                }
                                 @if (_refreshQueue.TryGetValue(program.ProgramRuvId, out ProgramRefreshStatus status) && status == ProgramRefreshStatus.Processing)
                                 {
                                     <span class="icon-button">
@@ -175,6 +189,7 @@ else
         _filterMonitored ||
         !string.IsNullOrEmpty(_filterChannel);
 
+    private MatchProgramDialog? _matchProgramDialog;
     private List<ProgramSummary>? _programs;
     private string _searchText = string.Empty;
     private readonly HashSet<int> _pendingRefresh = [];
@@ -266,6 +281,12 @@ else
         }
 
         await InvokeAsync(StateHasChanged);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
+    private async Task OpenMatchProgramDialog(ProgramSummary program)
+    {
+        await _matchProgramDialog!.OpenAsync(program.ProgramRuvId, program.TvdbSeriesId);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]

--- a/src/Ruvarr/Programs/Queries/GetProgram/GetProgramHandler.cs
+++ b/src/Ruvarr/Programs/Queries/GetProgram/GetProgramHandler.cs
@@ -20,6 +20,7 @@ internal sealed class GetProgramHandler(RuvarrDbContext dbContext) : IRequestHan
                 x.HasMissingEpisodes,
                 SeriesName = x.Series!.Name,
                 SeriesSlug = x.Series!.Slug,
+                SeriesTvdbId = (int?)x.Series!.TvdbId,
             })
             .Select(x => new ProgramSummary(
                 x.Channel,
@@ -28,6 +29,7 @@ internal sealed class GetProgramHandler(RuvarrDbContext dbContext) : IRequestHan
                 x.IsMonitored,
                 x.HasMissingEpisodes,
                 x.SeriesName,
-                x.SeriesSlug != null ? new Uri($"https://www.thetvdb.com/series/{Uri.EscapeDataString(x.SeriesSlug)}") : null))
+                x.SeriesSlug != null ? new Uri($"https://www.thetvdb.com/series/{Uri.EscapeDataString(x.SeriesSlug)}") : null,
+                x.SeriesTvdbId))
             .FirstOrDefaultAsync(cancellationToken);
 }

--- a/src/Ruvarr/Programs/Queries/GetPrograms/GetProgramsHandler.cs
+++ b/src/Ruvarr/Programs/Queries/GetPrograms/GetProgramsHandler.cs
@@ -60,6 +60,7 @@ internal sealed class GetProgramsHandler(RuvarrDbContext dbContext) : IStreaming
                 x.HasMissingEpisodes,
                 SeriesName = x.Series!.Name,
                 SeriesSlug = x.Series!.Slug,
+                SeriesTvdbId = (int?)x.Series!.TvdbId,
             })
             .AsAsyncEnumerable()
             .Select(x => new ProgramSummary(
@@ -69,7 +70,8 @@ internal sealed class GetProgramsHandler(RuvarrDbContext dbContext) : IStreaming
                 x.IsMonitored,
                 x.HasMissingEpisodes,
                 x.SeriesName,
-                x.SeriesSlug is { } slug ? new Uri($"https://www.thetvdb.com/series/{Uri.EscapeDataString(slug)}") : null));
+                x.SeriesSlug is { } slug ? new Uri($"https://www.thetvdb.com/series/{Uri.EscapeDataString(slug)}") : null,
+                x.SeriesTvdbId));
 
         await foreach (ProgramSummary summary in results.WithCancellation(cancellationToken))
         {

--- a/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
+++ b/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using Ruvarr.Contracts;
 using Ruvarr.Programs.Commands.DownloadEpisode;
 using Ruvarr.Programs.Commands.MatchEpisode;
+using Ruvarr.Programs.Commands.MatchProgram;
 using Ruvarr.Programs.Commands.MatchProgramEpisodes;
 using Ruvarr.Programs.Commands.RefreshProgram;
 using Ruvarr.Programs.Queries.GetProgram;
@@ -18,6 +19,7 @@ internal static class ServiceCollectionExtensions
         services.AddTransient<IStreamingRequestHandler<GetProgramsQuery, ProgramSummary>, GetProgramsHandler>();
         services.AddTransient<IRequestHandler<GetProgramEpisodesQuery, List<EpisodeSummary>>, GetProgramEpisodesHandler>();
         services.AddTransient<IRequestHandler<MatchEpisodeCommand>, MatchEpisodeHandler>();
+        services.AddTransient<IRequestHandler<MatchProgramCommand>, MatchProgramHandler>();
         services.AddTransient<IRequestHandler<DownloadEpisodeCommand>, DownloadEpisodeHandler>();
         services.AddTransient<IRequestHandler<MatchProgramEpisodesCommand>, MatchProgramEpisodesHandler>();
         services.AddTransient<IRequestHandler<RefreshProgramCommand>, RefreshProgramHandler>();

--- a/tests/Ruvarr.UnitTests/Programs/Commands/MatchProgram/MatchProgramHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Commands/MatchProgram/MatchProgramHandlerTests/Handle.cs
@@ -1,0 +1,209 @@
+using Microsoft.EntityFrameworkCore;
+
+using NSubstitute;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Infrastructure.Tvdb;
+using Ruvarr.Infrastructure.Tvdb.Models;
+using Ruvarr.Programs;
+using Ruvarr.Programs.Commands.MatchProgram;
+using Ruvarr.Programs.Domain;
+using Ruvarr.Testing.Builders;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.Commands.MatchProgram.MatchProgramHandlerTests;
+
+public sealed class Handle
+{
+    private readonly ITvdbClient _tvdb = Substitute.For<ITvdbClient>();
+    private readonly TvdbEpisodeLookupNotifier _episodeLookupNotifier = new();
+    private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
+
+    public Handle()
+    {
+        _serviceProvider.GetService(Arg.Any<Type>()).Returns(Array.Empty<object>());
+    }
+
+    private RuvarrDbContext CreateDbContext() => new(
+        new DbContextOptionsBuilder<RuvarrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options,
+        _serviceProvider);
+
+    private MatchProgramHandler CreateHandler(RuvarrDbContext dbContext) => new(
+        dbContext, _tvdb, _episodeLookupNotifier);
+
+    [Fact]
+    public async Task ReturnsValidationErrorWhenTvdbSeriesIdExceedsMaximumAllowed()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        MatchProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        RuvarrResult result = await sut.Handle(new MatchProgramCommand(1, 10_000_001), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(ProgramErrors.TvdbSeriesIdOutOfRange);
+        await _tvdb.DidNotReceive().GetSeriesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReturnsProgramNotFoundWhenProgramDoesNotExist()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        MatchProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        RuvarrResult result = await sut.Handle(new MatchProgramCommand(999, 12345), CancellationToken.None);
+
+        // Assert
+        result.Error.ShouldBe(ProgramErrors.ProgramNotFound);
+        _episodeLookupNotifier.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ReturnsTvdbSeriesNotFoundWhenTvdbClientReturnsNull()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+
+        _tvdb.GetSeriesAsync(12345, Arg.Any<CancellationToken>()).Returns((SeriesData?)null);
+
+        MatchProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        RuvarrResult result = await sut.Handle(new MatchProgramCommand(1, 12345), CancellationToken.None);
+
+        // Assert
+        result.Error.ShouldBe(TvdbErrors.SeriesNotFound);
+        _episodeLookupNotifier.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task MatchesProgramAndSavesWhenTvdbSeriesAlreadyExistsInDatabase()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).Build();
+        TvdbSeries existingSeries = new TvdbSeriesBuilder().WithId(12345).WithName("Existing Series").Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        dbContext.Set<TvdbSeries>().Add(existingSeries);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+
+        SeriesData seriesData = new TvdbSeriesDataBuilder().WithId(12345).WithName("Existing Series").Build();
+        _tvdb.GetSeriesAsync(12345, Arg.Any<CancellationToken>()).Returns(seriesData);
+
+        MatchProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        RuvarrResult result = await sut.Handle(new MatchProgramCommand(1, 12345), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        program.Series.ShouldBe(existingSeries);
+    }
+
+    [Fact]
+    public async Task MatchesProgramAndSavesWhenTvdbSeriesNotInDatabase()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+
+        SeriesData seriesData = new TvdbSeriesDataBuilder().WithId(12345).WithName("New Series").Build();
+        _tvdb.GetSeriesAsync(12345, Arg.Any<CancellationToken>()).Returns(seriesData);
+
+        MatchProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        RuvarrResult result = await sut.Handle(new MatchProgramCommand(1, 12345), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        program.Series.ShouldNotBeNull();
+        program.Series.TvdbId.ShouldBe(12345);
+        program.Series.Name.ShouldBe("New Series");
+    }
+
+    [Fact]
+    public async Task EnqueuesTvdbEpisodeLookupOnSuccess()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithName("Test Program").Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+
+        SeriesData seriesData = new TvdbSeriesDataBuilder().WithId(12345).WithName("Test Series").Build();
+        _tvdb.GetSeriesAsync(12345, Arg.Any<CancellationToken>()).Returns(seriesData);
+
+        MatchProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        RuvarrResult result = await sut.Handle(new MatchProgramCommand(1, 12345), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        _episodeLookupNotifier.Items.ShouldNotBeEmpty();
+        _episodeLookupNotifier.Items[0].RuvId.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task EnqueuesTvdbEpisodeLookupOnReMatch()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        TvdbSeries oldSeries = new TvdbSeriesBuilder().WithId(99999).WithName("Old Series").Build();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithName("Test Program").Build();
+        program.MatchTvdb(oldSeries);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+
+        SeriesData seriesData = new TvdbSeriesDataBuilder().WithId(12345).WithName("New Series").Build();
+        _tvdb.GetSeriesAsync(12345, Arg.Any<CancellationToken>()).Returns(seriesData);
+
+        MatchProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        RuvarrResult result = await sut.Handle(new MatchProgramCommand(1, 12345), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        _episodeLookupNotifier.Items.ShouldNotBeEmpty();
+        _episodeLookupNotifier.Items[0].RuvId.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task UpdatesSlugOnExistingTvdbSeriesOnMatch()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).Build();
+        TvdbSeries existingSeries = new TvdbSeriesBuilder().WithId(12345).WithSlug(null).Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        dbContext.Set<TvdbSeries>().Add(existingSeries);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+
+        SeriesData seriesData = new TvdbSeriesDataBuilder().WithId(12345).WithName("Existing Series").Build();
+        _tvdb.GetSeriesAsync(12345, Arg.Any<CancellationToken>()).Returns(seriesData);
+
+        MatchProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        RuvarrResult result = await sut.Handle(new MatchProgramCommand(1, 12345), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        existingSeries.Slug.ShouldBe("test-series");
+    }
+}

--- a/tests/Ruvarr.UnitTests/Programs/MatchProgramDialogTests/IsMatchDisabled.cs
+++ b/tests/Ruvarr.UnitTests/Programs/MatchProgramDialogTests/IsMatchDisabled.cs
@@ -1,0 +1,89 @@
+using Ruvarr.Programs;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.MatchProgramDialogTests;
+
+public sealed class IsMatchDisabled
+{
+    [Fact]
+    public void ReturnsTrueWhenInputIsEmpty()
+    {
+        // Arrange
+        string input = string.Empty;
+
+        // Act
+        bool result = MatchProgramDialog.IsMatchDisabled(input, currentTvdbSeriesId: null, isSubmitting: false);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("-100")]
+    public void ReturnsTrueWhenParsedValueIsNotPositive(string input)
+    {
+        // Arrange
+        // (input provided via theory)
+
+        // Act
+        bool result = MatchProgramDialog.IsMatchDisabled(input, currentTvdbSeriesId: null, isSubmitting: false);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ReturnsFalseWhenValidPositiveIntegerAndCurrentTvdbSeriesIdIsNull()
+    {
+        // Arrange
+        string input = "12345";
+
+        // Act
+        bool result = MatchProgramDialog.IsMatchDisabled(input, currentTvdbSeriesId: null, isSubmitting: false);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrueWhenParsedValueEqualsCurrentTvdbSeriesId()
+    {
+        // Arrange
+        string input = "12345";
+
+        // Act
+        bool result = MatchProgramDialog.IsMatchDisabled(input, currentTvdbSeriesId: 12345, isSubmitting: false);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ReturnsFalseWhenParsedValueDiffersFromCurrentTvdbSeriesId()
+    {
+        // Arrange
+        string input = "12345";
+
+        // Act
+        bool result = MatchProgramDialog.IsMatchDisabled(input, currentTvdbSeriesId: 99999, isSubmitting: false);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrueWhenIsSubmittingRegardlessOfInput()
+    {
+        // Arrange
+        string input = "12345";
+
+        // Act
+        bool result = MatchProgramDialog.IsMatchDisabled(input, currentTvdbSeriesId: null, isSubmitting: true);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}

--- a/tests/Ruvarr.UnitTests/Programs/MatchProgramDialogTests/SubmitMatch.cs
+++ b/tests/Ruvarr.UnitTests/Programs/MatchProgramDialogTests/SubmitMatch.cs
@@ -1,0 +1,71 @@
+using Bunit;
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+using NSubstitute;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Programs;
+using Ruvarr.Programs.Commands.MatchProgram;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.MatchProgramDialogTests;
+
+public sealed class SubmitMatch : BunitContext
+{
+    private readonly IRequestHandler<MatchProgramCommand> _handler;
+
+    public SubmitMatch()
+    {
+        _handler = Substitute.For<IRequestHandler<MatchProgramCommand>>();
+        _handler
+            .Handle(Arg.Any<MatchProgramCommand>(), Arg.Any<CancellationToken>())
+            .Returns(RuvarrResult.Success);
+        Services.AddTransient(_ => _handler);
+        Services.AddSingleton(Substitute.For<IJSRuntime>());
+    }
+
+    [Fact]
+    public async Task DisplaysErrorMessageWhenHandlerReturnsFailure()
+    {
+        // Arrange
+        RuvarrError error = new("Programs.Test", "Something went wrong.");
+        _handler
+            .Handle(Arg.Any<MatchProgramCommand>(), Arg.Any<CancellationToken>())
+            .Returns(RuvarrResult.Failure(error));
+
+        IRenderedComponent<MatchProgramDialog> cut = Render<MatchProgramDialog>();
+        await cut.Instance.OpenAsync(ruvId: 1, currentTvdbSeriesId: null);
+        await cut.Find("input").InputAsync(new ChangeEventArgs { Value = "12345" });
+
+        // Act
+        await cut.Find("button.dialog-button--primary").ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+        // Assert
+        cut.Markup.ShouldContain("Something went wrong.");
+    }
+
+    [Fact]
+    public async Task ClearsErrorMessageWhenDialogReopens()
+    {
+        // Arrange
+        RuvarrError error = new("Programs.Test", "Something went wrong.");
+        _handler
+            .Handle(Arg.Any<MatchProgramCommand>(), Arg.Any<CancellationToken>())
+            .Returns(RuvarrResult.Failure(error));
+
+        IRenderedComponent<MatchProgramDialog> cut = Render<MatchProgramDialog>();
+        await cut.Instance.OpenAsync(ruvId: 1, currentTvdbSeriesId: null);
+        await cut.Find("input").InputAsync(new ChangeEventArgs { Value = "12345" });
+        await cut.Find("button.dialog-button--primary").ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+        cut.Markup.ShouldContain("Something went wrong.");
+
+        // Act
+        await cut.Instance.OpenAsync(ruvId: 1, currentTvdbSeriesId: null);
+
+        // Assert
+        cut.Markup.ShouldNotContain("Something went wrong.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a link icon button to unmatched program rows that opens a `MatchProgramDialog` where the user can enter a numeric TVDB series ID
- The handler fetches the series from TVDB, reuses or creates the `TvdbSeries` row, calls `RuvProgram.MatchTvdb`, and always enqueues `TvdbEpisodeLookupNotifier` on success (including re-matches)
- Dialog stays open and displays an error message if the series ID is not found; `TvdbSeriesId` is validated to the range 1–10,000,000 before any outbound API call
- `ProgramSummary` gains a `TvdbSeriesId` field so the dialog can disable the Match button when the entered ID equals the current match

Closes #63

## Test plan

- [ ] Unmatched program rows show the link icon button; matched rows do not
- [ ] Entering a valid TVDB series ID matches the program and reloads the list
- [ ] Entering a non-existent ID keeps the dialog open with an error message
- [ ] Re-matching an already-matched program with a different ID overwrites the match
- [ ] Entering the current `TvdbSeriesId` disables the Match button
- [ ] `dotnet test` passes (317 tests, 0 warnings)