### PR TITLE
Order all queue pages by processing order

### DIFF
--- a/src/Ruvarr/Abstractions/QueueNotifier.cs
+++ b/src/Ruvarr/Abstractions/QueueNotifier.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 
@@ -9,9 +8,10 @@ namespace Ruvarr.Abstractions;
 public abstract class QueueNotifier<TItem> where TItem : notnull, IQueueItemSummary
 {
     private readonly Lock _lock = new();
-    private readonly Dictionary<int, TItem> _items = [];
+    private readonly Dictionary<int, (TItem Item, int Sequence)> _items = [];
     private readonly List<Channel<byte>> _subscribers = [];
     private readonly Channel<int> _channel = Channel.CreateUnbounded<int>();
+    private int _nextSequence;
 
     public void Enqueue(int ruvId, string programName)
     {
@@ -22,7 +22,7 @@ public abstract class QueueNotifier<TItem> where TItem : notnull, IQueueItemSumm
                 return;
             }
 
-            _items[ruvId] = CreatePending(ruvId, programName);
+            _items[ruvId] = (CreatePending(ruvId, programName), _nextSequence++);
         }
 
         _channel.Writer.TryWrite(ruvId);
@@ -33,9 +33,9 @@ public abstract class QueueNotifier<TItem> where TItem : notnull, IQueueItemSumm
     {
         lock (_lock)
         {
-            if (_items.TryGetValue(ruvId, out TItem? item))
+            if (_items.TryGetValue(ruvId, out (TItem Item, int Sequence) entry))
             {
-                _items[ruvId] = WithProcessingStatus(item);
+                _items[ruvId] = (WithProcessingStatus(entry.Item), entry.Sequence);
             }
         }
 
@@ -58,9 +58,10 @@ public abstract class QueueNotifier<TItem> where TItem : notnull, IQueueItemSumm
         {
             lock (_lock)
             {
-#pragma warning disable CA1309
-                return [.. _items.Values.OrderBy(x => x.ProgramName, StringComparer.Create(new CultureInfo("is-IS"), ignoreCase: true))];
-#pragma warning restore CA1309
+                return [.. _items.Values
+                    .OrderBy(x => !x.Item.IsProcessing)
+                    .ThenBy(x => x.Sequence)
+                    .Select(x => x.Item)];
             }
         }
     }

--- a/src/Ruvarr/Contracts/IQueueItemSummary.cs
+++ b/src/Ruvarr/Contracts/IQueueItemSummary.cs
@@ -3,4 +3,5 @@ namespace Ruvarr.Contracts;
 public interface IQueueItemSummary
 {
     string ProgramName { get; }
+    bool IsProcessing { get; }
 }

--- a/src/Ruvarr/Contracts/ProgramRefreshQueueItemSummary.cs
+++ b/src/Ruvarr/Contracts/ProgramRefreshQueueItemSummary.cs
@@ -3,4 +3,7 @@ namespace Ruvarr.Contracts;
 public sealed record ProgramRefreshQueueItemSummary(
     int RuvId,
     string ProgramName,
-    ProgramRefreshStatus Status) : IQueueItemSummary;
+    ProgramRefreshStatus Status) : IQueueItemSummary
+{
+    public bool IsProcessing => Status == ProgramRefreshStatus.Processing;
+}

--- a/src/Ruvarr/Contracts/TvdbEpisodeLookupQueueItemSummary.cs
+++ b/src/Ruvarr/Contracts/TvdbEpisodeLookupQueueItemSummary.cs
@@ -3,4 +3,7 @@ namespace Ruvarr.Contracts;
 public sealed record TvdbEpisodeLookupQueueItemSummary(
     int RuvId,
     string ProgramName,
-    TvdbEpisodeLookupStatus Status) : IQueueItemSummary;
+    TvdbEpisodeLookupStatus Status) : IQueueItemSummary
+{
+    public bool IsProcessing => Status == TvdbEpisodeLookupStatus.Processing;
+}

--- a/src/Ruvarr/Contracts/TvdbSeriesLookupQueueItemSummary.cs
+++ b/src/Ruvarr/Contracts/TvdbSeriesLookupQueueItemSummary.cs
@@ -3,4 +3,7 @@ namespace Ruvarr.Contracts;
 public sealed record TvdbSeriesLookupQueueItemSummary(
     int RuvId,
     string ProgramName,
-    TvdbSeriesLookupStatus Status) : IQueueItemSummary;
+    TvdbSeriesLookupStatus Status) : IQueueItemSummary
+{
+    public bool IsProcessing => Status == TvdbSeriesLookupStatus.Processing;
+}

--- a/src/Ruvarr/Downloads/Queries/GetDownloadQueue/GetDownloadQueueHandler.cs
+++ b/src/Ruvarr/Downloads/Queries/GetDownloadQueue/GetDownloadQueueHandler.cs
@@ -21,7 +21,8 @@ internal sealed class GetDownloadQueueHandler(RuvarrDbContext dbContext)
 
         return await query
             .OrderBy(x => x.Downloaded.HasValue)
-            .ThenByDescending(x => x.Created)
+            .ThenByDescending(x => x.Status == DownloadQueueStatus.Downloading)
+            .ThenBy(x => x.Created)
             .Select(x => new DownloadQueueItemSummary(
                 x.Episode.RuvId,
                 x.Episode.Title,

--- a/src/Ruvarr/ProgramRefreshQueue/Components/ProgramRefreshQueue.razor
+++ b/src/Ruvarr/ProgramRefreshQueue/Components/ProgramRefreshQueue.razor
@@ -26,7 +26,7 @@ else
             </tr>
         </thead>
         <tbody>
-            @foreach (ProgramRefreshQueueItemSummary item in _items.OrderByDescending(x => x.Status))
+            @foreach (ProgramRefreshQueueItemSummary item in _items)
             {
                 <tr>
                     <td>@item.ProgramName</td>

--- a/src/Ruvarr/TvdbEpisodeLookup/Components/TvdbEpisodeLookupQueue.razor
+++ b/src/Ruvarr/TvdbEpisodeLookup/Components/TvdbEpisodeLookupQueue.razor
@@ -26,7 +26,7 @@ else
             </tr>
         </thead>
         <tbody>
-            @foreach (TvdbEpisodeLookupQueueItemSummary item in _items.OrderByDescending(x => x.Status))
+            @foreach (TvdbEpisodeLookupQueueItemSummary item in _items)
             {
                 <tr>
                     <td>@item.ProgramName</td>

--- a/src/Ruvarr/TvdbSeriesLookup/Components/TvdbSeriesLookupQueue.razor
+++ b/src/Ruvarr/TvdbSeriesLookup/Components/TvdbSeriesLookupQueue.razor
@@ -26,7 +26,7 @@ else
             </tr>
         </thead>
         <tbody>
-            @foreach (TvdbSeriesLookupQueueItemSummary item in _items.OrderByDescending(x => x.Status))
+            @foreach (TvdbSeriesLookupQueueItemSummary item in _items)
             {
                 <tr>
                     <td>@item.ProgramName</td>

--- a/tests/Ruvarr.IntegrationTests/Programs/Episodes/Queries/GetDownloadQueueHandlerTests.cs
+++ b/tests/Ruvarr.IntegrationTests/Programs/Episodes/Queries/GetDownloadQueueHandlerTests.cs
@@ -24,6 +24,97 @@ public sealed class GetDownloadQueueHandlerTests(IntegrationTestFactory factory)
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
+    public async Task ReturnsPendingItemsSortedOldestFirst()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+        IRequestHandler<GetDownloadQueueQuery, List<DownloadQueueItemSummary>> handler =
+            scope.ServiceProvider.GetRequiredService<IRequestHandler<GetDownloadQueueQuery, List<DownloadQueueItemSummary>>>();
+
+        RuvProgram programA = RuvProgram.Create(2, "RÚV1", "Program A", null, multipleEpisodes: true);
+        RuvProgram programB = RuvProgram.Create(3, "RÚV1", "Program B", null, multipleEpisodes: true);
+        dbContext.Set<RuvProgram>().Add(programA);
+        dbContext.Set<RuvProgram>().Add(programB);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        programA.TryAddEpisode("EP001", new Uri("https://example.com/ep1.mp4"), "Episode 1", "Desc", DateTime.UtcNow);
+        programB.TryAddEpisode("EP002", new Uri("https://example.com/ep2.mp4"), "Episode 2", "Desc", DateTime.UtcNow);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        DateTime olderCreated = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        DateTime newerCreated = new(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        RuvEpisode episodeOlder = programA.Episodes[0];
+        RuvEpisode episodeNewer = programB.Episodes[0];
+        dbContext.EnqueueDownload(episodeOlder);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        dbContext.EnqueueDownload(episodeNewer);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        await dbContext.Database.ExecuteSqlAsync(
+            $"UPDATE download_queue SET created = {olderCreated.ToString("o")} WHERE id = (SELECT download_queue_item_id FROM episodes WHERE ruv_id = 'EP001')",
+            cancellationToken);
+        await dbContext.Database.ExecuteSqlAsync(
+            $"UPDATE download_queue SET created = {newerCreated.ToString("o")} WHERE id = (SELECT download_queue_item_id FROM episodes WHERE ruv_id = 'EP002')",
+            cancellationToken);
+
+        // Act
+        List<DownloadQueueItemSummary> items = await handler.Handle(
+            new GetDownloadQueueQuery(IncludeDownloaded: false),
+            cancellationToken);
+
+        // Assert
+        items.Count.ShouldBe(2);
+        items[0].EpisodeRuvId.ShouldBe("EP001");
+        items[1].EpisodeRuvId.ShouldBe("EP002");
+    }
+
+    [Fact]
+    public async Task ReturnsDownloadingItemBeforePendingItems()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+        IRequestHandler<GetDownloadQueueQuery, List<DownloadQueueItemSummary>> handler =
+            scope.ServiceProvider.GetRequiredService<IRequestHandler<GetDownloadQueueQuery, List<DownloadQueueItemSummary>>>();
+
+        RuvProgram programA = RuvProgram.Create(4, "RÚV1", "Program C", null, multipleEpisodes: true);
+        RuvProgram programB = RuvProgram.Create(5, "RÚV1", "Program D", null, multipleEpisodes: true);
+        dbContext.Set<RuvProgram>().Add(programA);
+        dbContext.Set<RuvProgram>().Add(programB);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        programA.TryAddEpisode("EP003", new Uri("https://example.com/ep3.mp4"), "Episode 3", "Desc", DateTime.UtcNow);
+        programB.TryAddEpisode("EP004", new Uri("https://example.com/ep4.mp4"), "Episode 4", "Desc", DateTime.UtcNow);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        RuvEpisode episodePending = programA.Episodes[0];
+        RuvEpisode episodeDownloading = programB.Episodes[0];
+        dbContext.EnqueueDownload(episodePending);
+        dbContext.EnqueueDownload(episodeDownloading);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        await dbContext.Database.ExecuteSqlAsync(
+            $"UPDATE download_queue SET status = 'Downloading' WHERE id = (SELECT download_queue_item_id FROM episodes WHERE ruv_id = 'EP004')",
+            cancellationToken);
+
+        // Act
+        List<DownloadQueueItemSummary> items = await handler.Handle(
+            new GetDownloadQueueQuery(IncludeDownloaded: false),
+            cancellationToken);
+
+        // Assert
+        items.Count.ShouldBe(2);
+        items[0].EpisodeRuvId.ShouldBe("EP004");
+        items[1].EpisodeRuvId.ShouldBe("EP003");
+    }
+
+    [Fact]
     public async Task DoesNotReturnOrphanedItems()
     {
         // Arrange

--- a/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/Items.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/Items.cs
@@ -50,4 +50,39 @@ public sealed class Items
         // Assert
         sut.Items.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void ReturnsPendingItemsInEnqueueOrder()
+    {
+        // Arrange
+        ProgramRefreshNotifier sut = new();
+
+        // Act
+        sut.Enqueue(2, "Program B");
+        sut.Enqueue(1, "Program A");
+
+        // Assert
+        IReadOnlyList<ProgramRefreshQueueItemSummary> items = sut.Items;
+        items.Count.ShouldBe(2);
+        items[0].RuvId.ShouldBe(2);
+        items[1].RuvId.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ReturnsProcessingItemBeforePendingItems()
+    {
+        // Arrange
+        ProgramRefreshNotifier sut = new();
+        sut.Enqueue(1, "Program A");
+        sut.Enqueue(2, "Program B");
+
+        // Act
+        sut.MarkProcessing(2);
+
+        // Assert
+        IReadOnlyList<ProgramRefreshQueueItemSummary> items = sut.Items;
+        items.Count.ShouldBe(2);
+        items[0].RuvId.ShouldBe(2);
+        items[1].RuvId.ShouldBe(1);
+    }
 }

--- a/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/Items.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbEpisodeLookupNotifierTests/Items.cs
@@ -50,4 +50,39 @@ public sealed class Items
         // Assert
         sut.Items.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void ReturnsPendingItemsInEnqueueOrder()
+    {
+        // Arrange
+        TvdbEpisodeLookupNotifier sut = new();
+
+        // Act
+        sut.Enqueue(2, "Program B");
+        sut.Enqueue(1, "Program A");
+
+        // Assert
+        IReadOnlyList<TvdbEpisodeLookupQueueItemSummary> items = sut.Items;
+        items.Count.ShouldBe(2);
+        items[0].RuvId.ShouldBe(2);
+        items[1].RuvId.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ReturnsProcessingItemBeforePendingItems()
+    {
+        // Arrange
+        TvdbEpisodeLookupNotifier sut = new();
+        sut.Enqueue(1, "Program A");
+        sut.Enqueue(2, "Program B");
+
+        // Act
+        sut.MarkProcessing(2);
+
+        // Assert
+        IReadOnlyList<TvdbEpisodeLookupQueueItemSummary> items = sut.Items;
+        items.Count.ShouldBe(2);
+        items[0].RuvId.ShouldBe(2);
+        items[1].RuvId.ShouldBe(1);
+    }
 }

--- a/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/Items.cs
+++ b/tests/Ruvarr.UnitTests/Programs/TvdbSeriesLookupNotifierTests/Items.cs
@@ -50,4 +50,39 @@ public sealed class Items
         // Assert
         sut.Items.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void ReturnsPendingItemsInEnqueueOrder()
+    {
+        // Arrange
+        TvdbSeriesLookupNotifier sut = new();
+
+        // Act
+        sut.Enqueue(2, "Program B");
+        sut.Enqueue(1, "Program A");
+
+        // Assert
+        IReadOnlyList<TvdbSeriesLookupQueueItemSummary> items = sut.Items;
+        items.Count.ShouldBe(2);
+        items[0].RuvId.ShouldBe(2);
+        items[1].RuvId.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ReturnsProcessingItemBeforePendingItems()
+    {
+        // Arrange
+        TvdbSeriesLookupNotifier sut = new();
+        sut.Enqueue(1, "Program A");
+        sut.Enqueue(2, "Program B");
+
+        // Act
+        sut.MarkProcessing(2);
+
+        // Assert
+        IReadOnlyList<TvdbSeriesLookupQueueItemSummary> items = sut.Items;
+        items.Count.ShouldBe(2);
+        items[0].RuvId.ShouldBe(2);
+        items[1].RuvId.ShouldBe(1);
+    }
 }


### PR DESCRIPTION
## Summary
- Download Queue now shows the Downloading item first, then Pending items oldest-first (matching `DownloadQueueProcessor`'s pick order), then Complete items last
- Program Refresh, TVDB Series Lookup, and TVDB Episode Lookup queues now show the Processing item first, followed by Pending items in enqueue order (FIFO), matching the order their background jobs dequeue them
- `QueueNotifier<T>` tracks a sequence counter on enqueue; `Items` sorts by `!IsProcessing` then sequence ascending; client-side `OrderByDescending(Status)` removed from the three Razor components

## Test Plan
- [ ] Download Queue: Pending items appear oldest-first; Downloading item appears above Pending
- [ ] Program Refresh / TVDB Series / TVDB Episode queues: items appear in enqueue order; Processing item is first
- [ ] All 325 tests pass