### PR TITLE
Add real-time program creation notifications

### DIFF
--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -2,6 +2,7 @@
 
 using Ruvarr.Abstractions;
 using Ruvarr.Infrastructure.Tvdb.Models;
+using Ruvarr.Programs.Events;
 using Ruvarr.RomanNumerals;
 
 namespace Ruvarr.Programs.Domain;
@@ -10,11 +11,16 @@ internal sealed class RuvProgram
 {
     private static readonly Regex SlugPattern = new(@"^[a-z0-9\-]{1,128}$", RegexOptions.Compiled);
 
+    private readonly List<IDomainEvent> _domainEvents = [];
     private readonly List<RuvEpisode> _episodes = [];
 
     private RuvProgram()
     {
     }
+
+    public IReadOnlyList<IDomainEvent> DomainEvents => _domainEvents;
+
+    public void ClearDomainEvents() => _domainEvents.Clear();
 
     public required int RuvId { get; init; }
 
@@ -71,16 +77,23 @@ internal sealed class RuvProgram
         }
     }
 
-    public static RuvProgram Create(int id, string channel, string name, string? foreignName, bool multipleEpisodes, string? slug = null) => new()
+    public static RuvProgram Create(int id, string channel, string name, string? foreignName, bool multipleEpisodes, string? slug = null)
     {
-        RuvId = id,
-        Channel = channel,
-        Name = name,
-        ForeignName = foreignName,
-        HasMultipleEpisodes = multipleEpisodes,
-        Created = DateTime.UtcNow,
-        Slug = SanitizeSlug(slug),
-    };
+        RuvProgram program = new()
+        {
+            RuvId = id,
+            Channel = channel,
+            Name = name,
+            ForeignName = foreignName,
+            HasMultipleEpisodes = multipleEpisodes,
+            Created = DateTime.UtcNow,
+            Slug = SanitizeSlug(slug),
+        };
+
+        program._domainEvents.Add(new ProgramCreatedEvent(program));
+
+        return program;
+    }
 
     public void UpdateSlug(string? slug) => Slug = SanitizeSlug(slug);
 

--- a/src/Ruvarr/Programs/Events/ProgramCreatedEvent.cs
+++ b/src/Ruvarr/Programs/Events/ProgramCreatedEvent.cs
@@ -1,0 +1,6 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Programs.Domain;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed record ProgramCreatedEvent(RuvProgram Program) : IDomainEvent;

--- a/src/Ruvarr/Programs/Events/ProgramCreatedEventHandler.cs
+++ b/src/Ruvarr/Programs/Events/ProgramCreatedEventHandler.cs
@@ -1,0 +1,13 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Programs.Notifiers;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed class ProgramCreatedEventHandler(ProgramCreatedNotifier notifier) : IDomainEventHandler<ProgramCreatedEvent>
+{
+    public Task Handle(ProgramCreatedEvent @event, CancellationToken cancellationToken)
+    {
+        notifier.Notify();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Ruvarr/Programs/Notifiers/ProgramCreatedNotifier.cs
+++ b/src/Ruvarr/Programs/Notifiers/ProgramCreatedNotifier.cs
@@ -1,0 +1,47 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+
+namespace Ruvarr.Programs.Notifiers;
+
+public sealed class ProgramCreatedNotifier
+{
+    private readonly Lock _lock = new();
+    private readonly List<Channel<byte>> _subscribers = [];
+
+    public async IAsyncEnumerable<byte> WatchAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Channel<byte> channel = Channel.CreateBounded<byte>(new BoundedChannelOptions(16)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+        });
+        lock (_lock) _subscribers.Add(channel);
+        await using CancellationTokenRegistration registration = cancellationToken.Register(
+            () => channel.Writer.TryComplete());
+
+        try
+        {
+            while (await channel.Reader.WaitToReadAsync(CancellationToken.None))
+            {
+                while (channel.Reader.TryRead(out byte item))
+                {
+                    yield return item;
+                }
+            }
+        }
+        finally
+        {
+            lock (_lock) _subscribers.Remove(channel);
+        }
+    }
+
+    public void Notify()
+    {
+        lock (_lock)
+        {
+            foreach (Channel<byte> subscriber in _subscribers)
+            {
+                subscriber.Writer.TryWrite(0);
+            }
+        }
+    }
+}

--- a/src/Ruvarr/Programs/Programs.razor
+++ b/src/Ruvarr/Programs/Programs.razor
@@ -7,9 +7,11 @@
 @using Ruvarr.ProgramRefreshQueue.Notifiers
 @using Ruvarr.Programs.Commands.MatchProgram
 @using Ruvarr.Programs.Commands.RefreshProgram
+@using Ruvarr.Programs.Notifiers
 @using Ruvarr.Programs.Queries.GetPrograms
 @inject IServiceScopeFactory ScopeFactory
 @inject ProgramRefreshNotifier RefreshNotifier
+@inject ProgramCreatedNotifier CreatedNotifier
 
 <h1>Programs</h1>
 
@@ -199,6 +201,7 @@ else
     protected override Task OnInitializedAsync()
     {
         _ = WatchAsync();
+        _ = WatchCreatedAsync();
         _ = LoadProgramsAsync();
         return Task.CompletedTask;
     }
@@ -213,6 +216,14 @@ else
                 _pendingRefresh.Remove(ruvId);
             }
             await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task WatchCreatedAsync()
+    {
+        await foreach (byte _ in CreatedNotifier.WatchAsync(_cts.Token))
+        {
+            await LoadProgramsAsync();
         }
     }
 

--- a/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
+++ b/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
@@ -5,6 +5,8 @@ using Ruvarr.Programs.Commands.MatchEpisode;
 using Ruvarr.Programs.Commands.MatchProgram;
 using Ruvarr.Programs.Commands.MatchProgramEpisodes;
 using Ruvarr.Programs.Commands.RefreshProgram;
+using Ruvarr.Programs.Events;
+using Ruvarr.Programs.Notifiers;
 using Ruvarr.Programs.Queries.GetProgram;
 using Ruvarr.Programs.Queries.GetProgramEpisodes;
 using Ruvarr.Programs.Queries.GetPrograms;
@@ -15,6 +17,8 @@ internal static class ServiceCollectionExtensions
 {
     internal static IServiceCollection AddPrograms(this IServiceCollection services)
     {
+        services.AddSingleton<ProgramCreatedNotifier>();
+        services.AddTransient<IDomainEventHandler<ProgramCreatedEvent>, ProgramCreatedEventHandler>();
         services.AddTransient<IRequestHandler<GetProgramQuery, ProgramSummary?>, GetProgramHandler>();
         services.AddTransient<IStreamingRequestHandler<GetProgramsQuery, ProgramSummary>, GetProgramsHandler>();
         services.AddTransient<IRequestHandler<GetProgramEpisodesQuery, List<EpisodeSummary>>, GetProgramEpisodesHandler>();

--- a/src/Ruvarr/RuvarrDbContext.cs
+++ b/src/Ruvarr/RuvarrDbContext.cs
@@ -18,10 +18,17 @@ public sealed class RuvarrDbContext(DbContextOptions<RuvarrDbContext> options, I
 
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {
-        List<IDomainEvent> events = [.. ChangeTracker.Entries<RuvEpisode>()
-            .SelectMany(e => e.Entity.DomainEvents)];
+        List<IDomainEvent> events = [
+            .. ChangeTracker.Entries<RuvEpisode>().SelectMany(e => e.Entity.DomainEvents),
+            .. ChangeTracker.Entries<RuvProgram>().SelectMany(e => e.Entity.DomainEvents),
+        ];
 
         foreach (EntityEntry<RuvEpisode> entry in ChangeTracker.Entries<RuvEpisode>().ToList())
+        {
+            entry.Entity.ClearDomainEvents();
+        }
+
+        foreach (EntityEntry<RuvProgram> entry in ChangeTracker.Entries<RuvProgram>().ToList())
         {
             entry.Entity.ClearDomainEvents();
         }

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/DomainEvents.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/DomainEvents.cs
@@ -1,0 +1,34 @@
+using Ruvarr.Programs.Domain;
+using Ruvarr.Programs.Events;
+using Ruvarr.Testing.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.Domain.RuvProgramTests;
+
+public sealed class DomainEvents
+{
+    [Fact]
+    public void Create_RaisesProgramCreatedEvent()
+    {
+        // Act
+        RuvProgram sut = new RuvProgramBuilder().Build();
+
+        // Assert
+        ProgramCreatedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProgramCreatedEvent>();
+        @event.Program.ShouldBe(sut);
+    }
+
+    [Fact]
+    public void ClearDomainEvents_ClearsAllEvents()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+
+        // Act
+        sut.ClearDomainEvents();
+
+        // Assert
+        sut.DomainEvents.ShouldBeEmpty();
+    }
+}

--- a/tests/Ruvarr.UnitTests/Programs/ProgramCreatedEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramCreatedEventHandlerTests/Handle.cs
@@ -1,0 +1,42 @@
+using Ruvarr.Programs.Domain;
+using Ruvarr.Programs.Events;
+using Ruvarr.Programs.Notifiers;
+using Ruvarr.Testing.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.ProgramCreatedEventHandlerTests;
+
+public sealed class Handle
+{
+    [Fact]
+    public async Task Handle_NotifiesSubscribers()
+    {
+        // Arrange
+        ProgramCreatedNotifier notifier = new();
+        ProgramCreatedEventHandler sut = new(notifier);
+        RuvProgram program = new RuvProgramBuilder().Build();
+        ProgramCreatedEvent @event = new(program);
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+
+        byte? received = null;
+        Task watchTask = Task.Run(async () =>
+        {
+            await foreach (byte b in notifier.WatchAsync(cts.Token))
+            {
+                received = b;
+                await cts.CancelAsync();
+            }
+        }, TestContext.Current.CancellationToken);
+
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Task.WhenAny(watchTask, Task.Delay(1000, TestContext.Current.CancellationToken));
+        received.ShouldNotBeNull();
+    }
+}

--- a/tests/Ruvarr.UnitTests/Programs/ProgramCreatedNotifierTests/Notify.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramCreatedNotifierTests/Notify.cs
@@ -1,0 +1,45 @@
+using Ruvarr.Programs.Notifiers;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.ProgramCreatedNotifierTests;
+
+public sealed class Notify
+{
+    [Fact]
+    public async Task Notify_SignalsAllSubscribers()
+    {
+        // Arrange
+        ProgramCreatedNotifier sut = new();
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+
+        byte? received = null;
+        Task watchTask = Task.Run(async () =>
+        {
+            await foreach (byte b in sut.WatchAsync(cts.Token))
+            {
+                received = b;
+                await cts.CancelAsync();
+            }
+        }, TestContext.Current.CancellationToken);
+
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+
+        // Act
+        sut.Notify();
+
+        // Assert
+        await Task.WhenAny(watchTask, Task.Delay(1000, TestContext.Current.CancellationToken));
+        received.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Notify_WithNoSubscribers_DoesNotThrow()
+    {
+        // Arrange
+        ProgramCreatedNotifier sut = new();
+
+        // Act & Assert
+        Should.NotThrow(() => sut.Notify());
+    }
+}


### PR DESCRIPTION
## Summary
- Raise `ProgramCreatedEvent` domain event from `RuvProgram.Create()` and dispatch it through the existing `SaveChangesAsync()` event pipeline
- Add `ProgramCreatedNotifier` (bounded channel with `DropOldest`) and `ProgramCreatedEventHandler` to bridge domain events to connected clients
- Subscribe in `Programs.razor` to re-fetch the program list on each notification signal, respecting active filters and sort order

## Test plan
- [x] Unit tests for `RuvProgram.Create()` raising `ProgramCreatedEvent`
- [x] Unit tests for `ClearDomainEvents()`
- [x] Unit tests for `ProgramCreatedNotifier.Notify()` signaling subscribers
- [x] Unit tests for `ProgramCreatedEventHandler.Handle()` triggering notification
- [x] All 330 existing tests pass (308 unit + 22 integration)
- [ ] Manual: run API, trigger program sync, verify programs page updates without refresh

Closes #51