### PR TITLE
Raise domain event from MatchTvdb to trigger episode lookup

### DIFF
--- a/src/Ruvarr/Programs/Commands/MatchProgram/MatchProgramHandler.cs
+++ b/src/Ruvarr/Programs/Commands/MatchProgram/MatchProgramHandler.cs
@@ -4,14 +4,12 @@ using Ruvarr.Abstractions;
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
 using Ruvarr.Programs.Domain;
-using Ruvarr.TvdbEpisodeLookup.Notifiers;
 
 namespace Ruvarr.Programs.Commands.MatchProgram;
 
 internal sealed class MatchProgramHandler(
     RuvarrDbContext dbContext,
-    ITvdbClient tvdb,
-    TvdbEpisodeLookupNotifier episodeLookupNotifier) : IRequestHandler<MatchProgramCommand>
+    ITvdbClient tvdb) : IRequestHandler<MatchProgramCommand>
 {
     public async Task<RuvarrResult> Handle(MatchProgramCommand command, CancellationToken cancellationToken)
     {
@@ -49,8 +47,6 @@ internal sealed class MatchProgramHandler(
         program.MatchTvdb(entity);
 
         await dbContext.SaveChangesAsync(cancellationToken);
-
-        episodeLookupNotifier.Enqueue(program.RuvId, program.Name);
 
         return RuvarrResult.Success;
     }

--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -110,6 +110,7 @@ internal sealed class RuvProgram
         NextLookup = null;
         Matched = DateTime.UtcNow;
         Series = series;
+        _domainEvents.Add(new ProgramMatchedTvdbEvent(RuvId, Name));
     }
 
     public void MatchTmdb(TmdbMovie movie)

--- a/src/Ruvarr/Programs/Events/ProgramMatchedTvdbEvent.cs
+++ b/src/Ruvarr/Programs/Events/ProgramMatchedTvdbEvent.cs
@@ -1,0 +1,5 @@
+using Ruvarr.Abstractions;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed record ProgramMatchedTvdbEvent(int RuvId, string Name) : IDomainEvent;

--- a/src/Ruvarr/Programs/Events/ProgramMatchedTvdbEventHandler.cs
+++ b/src/Ruvarr/Programs/Events/ProgramMatchedTvdbEventHandler.cs
@@ -1,0 +1,13 @@
+using Ruvarr.Abstractions;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed class ProgramMatchedTvdbEventHandler(TvdbEpisodeLookupNotifier notifier) : IDomainEventHandler<ProgramMatchedTvdbEvent>
+{
+    public Task Handle(ProgramMatchedTvdbEvent @event, CancellationToken cancellationToken)
+    {
+        notifier.Enqueue(@event.RuvId, @event.Name);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
+++ b/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ internal static class ServiceCollectionExtensions
     {
         services.AddSingleton<ProgramCreatedNotifier>();
         services.AddTransient<IDomainEventHandler<ProgramCreatedEvent>, ProgramCreatedEventHandler>();
+        services.AddTransient<IDomainEventHandler<ProgramMatchedTvdbEvent>, ProgramMatchedTvdbEventHandler>();
         services.AddTransient<IRequestHandler<GetProgramQuery, ProgramSummary?>, GetProgramHandler>();
         services.AddTransient<IStreamingRequestHandler<GetProgramsQuery, ProgramSummary>, GetProgramsHandler>();
         services.AddTransient<IRequestHandler<GetProgramEpisodesQuery, List<EpisodeSummary>>, GetProgramEpisodesHandler>();

--- a/src/Ruvarr/TvdbSeriesLookup/Jobs/TvdbSeriesLookupJob.cs
+++ b/src/Ruvarr/TvdbSeriesLookup/Jobs/TvdbSeriesLookupJob.cs
@@ -8,7 +8,6 @@ using Ruvarr.Extensions;
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
 using Ruvarr.Programs.Domain;
-using Ruvarr.TvdbEpisodeLookup.Notifiers;
 using Ruvarr.TvdbSeriesLookup.Notifiers;
 
 namespace Ruvarr.TvdbSeriesLookup.Jobs;
@@ -18,8 +17,7 @@ internal sealed class TvdbSeriesLookupJob(
     ILogger<TvdbSeriesLookupJob> logger,
     RuvarrDbContext dbContext,
     ITvdbClient tvdb,
-    TvdbSeriesLookupNotifier lookupQueue,
-    TvdbEpisodeLookupNotifier episodeLookupQueue) : IJob
+    TvdbSeriesLookupNotifier lookupQueue) : IJob
 {
     public async Task Execute(IJobExecutionContext context)
     {
@@ -95,15 +93,11 @@ internal sealed class TvdbSeriesLookupJob(
 
         program.MatchTvdb(entity);
 
-        int added = await dbContext.SaveChangesAsync(context.CancellationToken);
+        await dbContext.SaveChangesAsync(context.CancellationToken);
 
         lookupQueue.MarkComplete(ruvId);
 
-        if (added > 0)
-        {
-            logger.LogInformation("Matched RÚV program '{Program}' with TVDB series '{Series}'", program.Name, entity.Name);
-            episodeLookupQueue.Enqueue(program.RuvId, program.Name);
-        }
+        logger.LogInformation("Matched RÚV program '{Program}' with TVDB series '{Series}'", program.Name, entity.Name);
     }
 
     private async Task ScheduleLookupAsync(RuvProgram program, CancellationToken cancellationToken)

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbSeriesLookupJobTests/SlugRefresh.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbSeriesLookupJobTests/SlugRefresh.cs
@@ -7,7 +7,6 @@ using Quartz;
 
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
-using Ruvarr.TvdbEpisodeLookup.Notifiers;
 using Ruvarr.TvdbSeriesLookup.Jobs;
 using Ruvarr.TvdbSeriesLookup.Notifiers;
 using Ruvarr.Programs.Domain;
@@ -21,7 +20,6 @@ public sealed class SlugRefresh
 {
     private readonly ITvdbClient _tvdb = Substitute.For<ITvdbClient>();
     private readonly TvdbSeriesLookupNotifier _lookupQueue = new();
-    private readonly TvdbEpisodeLookupNotifier _episodeLookupQueue = new();
     private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
     private readonly IJobExecutionContext _context = Substitute.For<IJobExecutionContext>();
 
@@ -41,8 +39,7 @@ public sealed class SlugRefresh
         NullLogger<TvdbSeriesLookupJob>.Instance,
         dbContext,
         _tvdb,
-        _lookupQueue,
-        _episodeLookupQueue);
+        _lookupQueue);
 
     [Fact]
     public async Task CallsGetSeriesAsync_WithParsedTvdbId_WhenSeriesIsNotNull()
@@ -151,29 +148,6 @@ public sealed class SlugRefresh
     }
 
     [Fact]
-    public async Task DoesNotEnqueueEpisodeLookup_WhenSeriesIsNotNull()
-    {
-        // Arrange
-        using RuvarrDbContext dbContext = CreateDbContext();
-        TvdbSeries series = new TvdbSeriesBuilder().WithId(1000).WithSlug(null).Build();
-        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).Build();
-        program.MatchTvdb(series);
-        dbContext.Set<RuvProgram>().Add(program);
-        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
-
-        SeriesData seriesData = new TvdbSeriesDataBuilder().WithId(1000).Build();
-        _tvdb.GetSeriesAsync(1000, Arg.Any<CancellationToken>()).Returns(seriesData);
-        _lookupQueue.Enqueue(1, program.Name);
-        TvdbSeriesLookupJob sut = CreateJob(dbContext);
-
-        // Act
-        await sut.Execute(_context);
-
-        // Assert
-        _episodeLookupQueue.Items.ShouldBeEmpty();
-    }
-
-    [Fact]
     public async Task NoSideEffects_WhenGetSeriesAsyncReturnsNull()
     {
         // Arrange
@@ -194,6 +168,5 @@ public sealed class SlugRefresh
         // Assert
         program.NextLookup.ShouldBeNull();
         program.Series!.Slug.ShouldBeNull();
-        _episodeLookupQueue.Items.ShouldBeEmpty();
     }
 }

--- a/tests/Ruvarr.UnitTests/Programs/Commands/MatchProgram/MatchProgramHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Commands/MatchProgram/MatchProgramHandlerTests/Handle.cs
@@ -8,6 +8,7 @@ using Ruvarr.Infrastructure.Tvdb.Models;
 using Ruvarr.Programs;
 using Ruvarr.Programs.Commands.MatchProgram;
 using Ruvarr.Programs.Domain;
+using Ruvarr.Programs.Events;
 using Ruvarr.Testing.Builders;
 using Ruvarr.TvdbEpisodeLookup.Notifiers;
 
@@ -33,7 +34,15 @@ public sealed class Handle
         _serviceProvider);
 
     private MatchProgramHandler CreateHandler(RuvarrDbContext dbContext) => new(
-        dbContext, _tvdb, _episodeLookupNotifier);
+        dbContext, _tvdb);
+
+    private void RegisterEventHandler()
+    {
+        ProgramMatchedTvdbEventHandler handler = new(_episodeLookupNotifier);
+        _serviceProvider
+            .GetService(typeof(IEnumerable<IDomainEventHandler<ProgramMatchedTvdbEvent>>))
+            .Returns(new IDomainEventHandler<ProgramMatchedTvdbEvent>[] { handler });
+    }
 
     [Fact]
     public async Task ReturnsValidationErrorWhenTvdbSeriesIdExceedsMaximumAllowed()
@@ -139,6 +148,7 @@ public sealed class Handle
     public async Task EnqueuesTvdbEpisodeLookupOnSuccess()
     {
         // Arrange
+        RegisterEventHandler();
         using RuvarrDbContext dbContext = CreateDbContext();
         RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithName("Test Program").Build();
         dbContext.Set<RuvProgram>().Add(program);
@@ -162,6 +172,7 @@ public sealed class Handle
     public async Task EnqueuesTvdbEpisodeLookupOnReMatch()
     {
         // Arrange
+        RegisterEventHandler();
         using RuvarrDbContext dbContext = CreateDbContext();
         TvdbSeries oldSeries = new TvdbSeriesBuilder().WithId(99999).WithName("Old Series").Build();
         RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithName("Test Program").Build();

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/MatchTvdb.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/MatchTvdb.cs
@@ -1,4 +1,5 @@
 using Ruvarr.Programs.Domain;
+using Ruvarr.Programs.Events;
 using Ruvarr.Testing.Builders;
 
 using Shouldly;
@@ -62,5 +63,21 @@ public sealed class MatchTvdb
 
         // Assert
         sut.LookupCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RaisesProgramMatchedTvdbEvent()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().WithRuvId(42).WithName("Test Program").Build();
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.MatchTvdb(new TvdbSeriesBuilder().Build());
+
+        // Assert
+        ProgramMatchedTvdbEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProgramMatchedTvdbEvent>();
+        @event.RuvId.ShouldBe(42);
+        @event.Name.ShouldBe("Test Program");
     }
 }

--- a/tests/Ruvarr.UnitTests/Programs/ProgramMatchedTvdbEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramMatchedTvdbEventHandlerTests/Handle.cs
@@ -1,0 +1,26 @@
+using Ruvarr.Programs.Events;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.ProgramMatchedTvdbEventHandlerTests;
+
+public sealed class Handle
+{
+    [Fact]
+    public async Task EnqueuesTvdbEpisodeLookup()
+    {
+        // Arrange
+        TvdbEpisodeLookupNotifier notifier = new();
+        ProgramMatchedTvdbEventHandler sut = new(notifier);
+        ProgramMatchedTvdbEvent @event = new(42, "Test Program");
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        notifier.Items.ShouldHaveSingleItem();
+        notifier.Items[0].RuvId.ShouldBe(42);
+        notifier.Items[0].ProgramName.ShouldBe("Test Program");
+    }
+}


### PR DESCRIPTION
## Summary
- Replace direct `TvdbEpisodeLookupNotifier.Enqueue` calls in `TvdbSeriesLookupJob` and `MatchProgramHandler` with a `ProgramMatchedTvdbEvent` domain event raised from `RuvProgram.MatchTvdb()`
- New `ProgramMatchedTvdbEventHandler` handles the event and enqueues episode lookup via the existing domain event dispatch infrastructure
- Both callers no longer depend on `TvdbEpisodeLookupNotifier`

Closes #120

## Test plan
- [x] New unit test verifies `MatchTvdb` raises `ProgramMatchedTvdbEvent` with correct `RuvId` and `Name`
- [x] New unit test verifies `ProgramMatchedTvdbEventHandler` calls `Enqueue` on the notifier
- [x] Updated `MatchProgramHandler` tests verify episode lookup enqueue via domain event dispatch chain
- [x] Updated `TvdbSeriesLookupJob` tests reflect removed `TvdbEpisodeLookupNotifier` dependency
- [x] All 335 tests pass (309 unit + 26 integration)