### PR TITLE
Raise domain event from RuvProgram.SetMonitoredStatus()

### DIFF
--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -100,7 +100,16 @@ internal sealed class RuvProgram
     private static string? SanitizeSlug(string? slug) =>
         slug is not null && SlugPattern.IsMatch(slug) ? slug : null;
 
-    public void SetMonitoredStatus(bool monitored) => IsMonitored = monitored;
+    public void SetMonitoredStatus(bool monitored)
+    {
+        if (IsMonitored == monitored)
+        {
+            return;
+        }
+
+        IsMonitored = monitored;
+        _domainEvents.Add(new ProgramMonitoredStatusChangedEvent(RuvId, monitored));
+    }
 
     public void SetHasMissingEpisodes(bool hasMissingEpisodes) => HasMissingEpisodes = hasMissingEpisodes;
 

--- a/src/Ruvarr/Programs/Events/ProgramMonitoredStatusChangedEvent.cs
+++ b/src/Ruvarr/Programs/Events/ProgramMonitoredStatusChangedEvent.cs
@@ -1,0 +1,5 @@
+using Ruvarr.Abstractions;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed record ProgramMonitoredStatusChangedEvent(int RuvId, bool IsMonitored) : IDomainEvent;

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/DomainEvents.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/DomainEvents.cs
@@ -31,4 +31,52 @@ public sealed class DomainEvents
         // Assert
         sut.DomainEvents.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void SetMonitoredStatus_FromFalseToTrue_RaisesProgramMonitoredStatusChangedEvent()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.SetMonitoredStatus(true);
+
+        // Assert
+        ProgramMonitoredStatusChangedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProgramMonitoredStatusChangedEvent>();
+        @event.RuvId.ShouldBe(sut.RuvId);
+        @event.IsMonitored.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetMonitoredStatus_FromTrueToFalse_RaisesProgramMonitoredStatusChangedEvent()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+        sut.ClearDomainEvents();
+        sut.SetMonitoredStatus(true);
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.SetMonitoredStatus(false);
+
+        // Assert
+        ProgramMonitoredStatusChangedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProgramMonitoredStatusChangedEvent>();
+        @event.RuvId.ShouldBe(sut.RuvId);
+        @event.IsMonitored.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SetMonitoredStatus_SameValue_DoesNotRaiseEvent()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.SetMonitoredStatus(false);
+
+        // Assert
+        sut.DomainEvents.ShouldBeEmpty();
+    }
 }


### PR DESCRIPTION
## Summary
- Add `ProgramMonitoredStatusChangedEvent` domain event (`internal sealed record` with `RuvId` and `IsMonitored`)
- Raise it from `SetMonitoredStatus()` only when the value actually changes
- No-op guard prevents redundant events during hourly sync cycles

## Test plan
- [x] Unit test: false-to-true raises event with correct payload
- [x] Unit test: true-to-false raises event with correct payload
- [x] Unit test: same-value does not raise event
- [x] All 338 existing tests pass

Closes #125