### PR TITLE
Raise domain event from SetHasMissingEpisodes

### DIFF
--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -111,7 +111,16 @@ internal sealed class RuvProgram
         _domainEvents.Add(new ProgramMonitoredStatusChangedEvent(RuvId, monitored));
     }
 
-    public void SetHasMissingEpisodes(bool hasMissingEpisodes) => HasMissingEpisodes = hasMissingEpisodes;
+    public void SetHasMissingEpisodes(bool hasMissingEpisodes)
+    {
+        if (HasMissingEpisodes == hasMissingEpisodes)
+        {
+            return;
+        }
+
+        HasMissingEpisodes = hasMissingEpisodes;
+        _domainEvents.Add(new ProgramMissingEpisodesChangedEvent(RuvId, hasMissingEpisodes));
+    }
 
     public void MatchTvdb(TvdbSeries series)
     {

--- a/src/Ruvarr/Programs/Events/ProgramMissingEpisodesChangedEvent.cs
+++ b/src/Ruvarr/Programs/Events/ProgramMissingEpisodesChangedEvent.cs
@@ -1,0 +1,5 @@
+using Ruvarr.Abstractions;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed record ProgramMissingEpisodesChangedEvent(int RuvId, bool HasMissingEpisodes) : IDomainEvent;

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/DomainEvents.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/DomainEvents.cs
@@ -79,4 +79,52 @@ public sealed class DomainEvents
         // Assert
         sut.DomainEvents.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void SetHasMissingEpisodes_FromFalseToTrue_RaisesProgramMissingEpisodesChangedEvent()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.SetHasMissingEpisodes(true);
+
+        // Assert
+        ProgramMissingEpisodesChangedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProgramMissingEpisodesChangedEvent>();
+        @event.RuvId.ShouldBe(sut.RuvId);
+        @event.HasMissingEpisodes.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetHasMissingEpisodes_FromTrueToFalse_RaisesProgramMissingEpisodesChangedEvent()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+        sut.ClearDomainEvents();
+        sut.SetHasMissingEpisodes(true);
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.SetHasMissingEpisodes(false);
+
+        // Assert
+        ProgramMissingEpisodesChangedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProgramMissingEpisodesChangedEvent>();
+        @event.RuvId.ShouldBe(sut.RuvId);
+        @event.HasMissingEpisodes.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SetHasMissingEpisodes_SameValue_DoesNotRaiseEvent()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.SetHasMissingEpisodes(false);
+
+        // Assert
+        sut.DomainEvents.ShouldBeEmpty();
+    }
 }


### PR DESCRIPTION
## Summary
- Add `ProgramMissingEpisodesChangedEvent` domain event record
- Raise it from `RuvProgram.SetHasMissingEpisodes()` only when the value changes, matching the `SetMonitoredStatus` pattern
- Add unit tests covering false-to-true, true-to-false, and same-value scenarios

## Test plan
- [x] Unit tests pass for false-to-true raising event
- [x] Unit tests pass for true-to-false raising event
- [x] Unit tests pass for same-value not raising event
- [x] Full test suite passes (341 tests)

Closes #126