### PR TITLE
Raise domain event from RuvEpisode.Match()

### DIFF
--- a/src/Ruvarr/Programs/Domain/RuvEpisode.cs
+++ b/src/Ruvarr/Programs/Domain/RuvEpisode.cs
@@ -125,6 +125,7 @@ internal sealed partial class RuvEpisode
 
     public void Match(int tvdbId, int season, int episode, bool isMissing)
     {
+        _domainEvents.Add(new EpisodeMatchedEvent(this));
         Matched = DateTime.UtcNow;
         NextLookup = null;
         TvdbId = tvdbId;

--- a/src/Ruvarr/Programs/Events/EpisodeMatchedEvent.cs
+++ b/src/Ruvarr/Programs/Events/EpisodeMatchedEvent.cs
@@ -1,0 +1,6 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Programs.Domain;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed record EpisodeMatchedEvent(RuvEpisode Episode) : IDomainEvent;

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/DomainEvents.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/DomainEvents.cs
@@ -65,21 +65,7 @@ public sealed class DomainEvents
     }
 
     [Fact]
-    public void Match_WhenIsMissingTrue_RaisesEpisodeMissingEvent()
-    {
-        // Arrange
-        RuvEpisode sut = new RuvEpisodeBuilder().Build();
-
-        // Act
-        sut.Match(tvdbId: 1, season: 1, episode: 1, isMissing: true);
-
-        // Assert
-        EpisodeMissingEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<EpisodeMissingEvent>();
-        @event.Episode.ShouldBe(sut);
-    }
-
-    [Fact]
-    public void Match_WhenIsMissingFalse_DoesNotRaiseEvent()
+    public void Match_RaisesEpisodeMatchedEvent()
     {
         // Arrange
         RuvEpisode sut = new RuvEpisodeBuilder().Build();
@@ -88,6 +74,38 @@ public sealed class DomainEvents
         sut.Match(tvdbId: 1, season: 1, episode: 1, isMissing: false);
 
         // Assert
-        sut.DomainEvents.ShouldBeEmpty();
+        EpisodeMatchedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<EpisodeMatchedEvent>();
+        @event.Episode.ShouldBe(sut);
+    }
+
+    [Fact]
+    public void Match_WhenIsMissingTrue_RaisesBothEvents()
+    {
+        // Arrange
+        RuvEpisode sut = new RuvEpisodeBuilder().Build();
+
+        // Act
+        sut.Match(tvdbId: 1, season: 1, episode: 1, isMissing: true);
+
+        // Assert
+        sut.DomainEvents.Count.ShouldBe(2);
+        sut.DomainEvents[0].ShouldBeOfType<EpisodeMatchedEvent>().Episode.ShouldBe(sut);
+        sut.DomainEvents[1].ShouldBeOfType<EpisodeMissingEvent>().Episode.ShouldBe(sut);
+    }
+
+    [Fact]
+    public void Match_OnRematch_RaisesEpisodeMatchedEvent()
+    {
+        // Arrange
+        RuvEpisode sut = new RuvEpisodeBuilder().Build();
+        sut.Match(tvdbId: 1, season: 1, episode: 1, isMissing: false);
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.Match(tvdbId: 2, season: 2, episode: 5, isMissing: false);
+
+        // Assert
+        EpisodeMatchedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<EpisodeMatchedEvent>();
+        @event.Episode.ShouldBe(sut);
     }
 }


### PR DESCRIPTION
## Summary

- Add `EpisodeMatchedEvent` domain event raised unconditionally from `RuvEpisode.Match()`
- Enables subscribers to react to successful TVDB episode matches, consistent with `ProgramMatchedTvdbEvent`
- Add 3 unit tests covering happy path, both-events-when-missing, and re-match scenarios

Closes #127