### PR TITLE
Replace imperative notifier calls with domain events in DownloadQueueItem

### DIFF
--- a/src/Ruvarr/Downloads/Domain/DownloadQueueItem.cs
+++ b/src/Ruvarr/Downloads/Domain/DownloadQueueItem.cs
@@ -1,13 +1,21 @@
-﻿using Ruvarr.Contracts;
+﻿using Ruvarr.Abstractions;
+using Ruvarr.Contracts;
+using Ruvarr.Downloads.Events;
 using Ruvarr.Programs.Domain;
 
 namespace Ruvarr.Downloads.Domain;
 
 internal sealed class DownloadQueueItem
 {
+    private readonly List<IDomainEvent> _domainEvents = [];
+
     private DownloadQueueItem()
     {
     }
+
+    public IReadOnlyList<IDomainEvent> DomainEvents => _domainEvents;
+
+    public void ClearDomainEvents() => _domainEvents.Clear();
 
     public required RuvEpisode Episode { get; init; }
 
@@ -23,11 +31,16 @@ internal sealed class DownloadQueueItem
         Created = DateTime.UtcNow,
     };
 
-    public void MarkDownloading() => Status = DownloadQueueStatus.Downloading;
+    public void MarkDownloading()
+    {
+        Status = DownloadQueueStatus.Downloading;
+        _domainEvents.Add(new DownloadStartedEvent(this));
+    }
 
     public void MarkDownloaded()
     {
         Downloaded = DateTime.UtcNow;
         Status = DownloadQueueStatus.Complete;
+        _domainEvents.Add(new DownloadCompletedEvent(this));
     }
 }

--- a/src/Ruvarr/Downloads/Events/DownloadCompletedEvent.cs
+++ b/src/Ruvarr/Downloads/Events/DownloadCompletedEvent.cs
@@ -1,0 +1,6 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Downloads.Domain;
+
+namespace Ruvarr.Downloads.Events;
+
+internal sealed record DownloadCompletedEvent(DownloadQueueItem Item) : IDomainEvent;

--- a/src/Ruvarr/Downloads/Events/DownloadCompletedEventHandler.cs
+++ b/src/Ruvarr/Downloads/Events/DownloadCompletedEventHandler.cs
@@ -1,0 +1,13 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Downloads.Notifiers;
+
+namespace Ruvarr.Downloads.Events;
+
+internal sealed class DownloadCompletedEventHandler(DownloadQueueNotifier notifier) : IDomainEventHandler<DownloadCompletedEvent>
+{
+    public Task Handle(DownloadCompletedEvent @event, CancellationToken cancellationToken)
+    {
+        notifier.Notify();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Ruvarr/Downloads/Events/DownloadStartedEvent.cs
+++ b/src/Ruvarr/Downloads/Events/DownloadStartedEvent.cs
@@ -1,0 +1,6 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Downloads.Domain;
+
+namespace Ruvarr.Downloads.Events;
+
+internal sealed record DownloadStartedEvent(DownloadQueueItem Item) : IDomainEvent;

--- a/src/Ruvarr/Downloads/Events/DownloadStartedEventHandler.cs
+++ b/src/Ruvarr/Downloads/Events/DownloadStartedEventHandler.cs
@@ -1,0 +1,13 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Downloads.Notifiers;
+
+namespace Ruvarr.Downloads.Events;
+
+internal sealed class DownloadStartedEventHandler(DownloadQueueNotifier notifier) : IDomainEventHandler<DownloadStartedEvent>
+{
+    public Task Handle(DownloadStartedEvent @event, CancellationToken cancellationToken)
+    {
+        notifier.Notify();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Ruvarr/Downloads/ServiceCollectionExtensions.cs
+++ b/src/Ruvarr/Downloads/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Ruvarr.Abstractions;
 using Ruvarr.Contracts;
+using Ruvarr.Downloads.Events;
 using Ruvarr.Downloads.Notifiers;
 using Ruvarr.Downloads.Queries.GetDownloadQueue;
 using Ruvarr.Programs.Events;
@@ -13,6 +14,8 @@ internal static class ServiceCollectionExtensions
         services.AddSingleton<DownloadQueueNotifier>();
         services.AddTransient<IRequestHandler<GetDownloadQueueQuery, List<DownloadQueueItemSummary>>, GetDownloadQueueHandler>();
         services.AddTransient<IDomainEventHandler<EpisodeMissingEvent>, EpisodeMissingEventHandler>();
+        services.AddTransient<IDomainEventHandler<DownloadStartedEvent>, DownloadStartedEventHandler>();
+        services.AddTransient<IDomainEventHandler<DownloadCompletedEvent>, DownloadCompletedEventHandler>();
 
         return services;
     }

--- a/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
+++ b/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
@@ -6,7 +6,6 @@ using Quartz;
 
 using Ruvarr.Contracts;
 using Ruvarr.Downloads.Domain;
-using Ruvarr.Downloads.Notifiers;
 using Ruvarr.Infrastructure.FFmpeg;
 using Ruvarr.Infrastructure.Sonarr;
 using Ruvarr.Infrastructure.Sonarr.Models;
@@ -19,8 +18,7 @@ internal class DownloadQueueProcessor(
     RuvarrDbContext dbContext,
     ISonarrClient sonarr,
     IFfmpegService ffmpeg,
-    IOptions<RuvarrOptions> options,
-    DownloadQueueNotifier notifier) : IJob
+    IOptions<RuvarrOptions> options) : IJob
 {
     public async Task Execute(IJobExecutionContext context)
     {
@@ -50,7 +48,6 @@ internal class DownloadQueueProcessor(
 
         item.MarkDownloading();
         await dbContext.SaveChangesAsync();
-        notifier.Notify();
 
         logger.LogInformation("Downloading {Program} - {Title}", item.Episode.Program.Name, item.Episode.Title);
         string tentativePath = item.Episode.ToFilePath(
@@ -76,7 +73,6 @@ internal class DownloadQueueProcessor(
         item.MarkDownloaded();
 
         await dbContext.SaveChangesAsync();
-        notifier.Notify();
 
         if (item.Episode.TvdbId == null)
         {

--- a/src/Ruvarr/RuvarrDbContext.cs
+++ b/src/Ruvarr/RuvarrDbContext.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 using Ruvarr.Abstractions;
+using Ruvarr.Downloads.Domain;
 using Ruvarr.Programs.Domain;
 
 namespace Ruvarr;
@@ -21,6 +22,7 @@ public sealed class RuvarrDbContext(DbContextOptions<RuvarrDbContext> options, I
         List<IDomainEvent> events = [
             .. ChangeTracker.Entries<RuvEpisode>().SelectMany(e => e.Entity.DomainEvents),
             .. ChangeTracker.Entries<RuvProgram>().SelectMany(e => e.Entity.DomainEvents),
+            .. ChangeTracker.Entries<DownloadQueueItem>().SelectMany(e => e.Entity.DomainEvents),
         ];
 
         foreach (EntityEntry<RuvEpisode> entry in ChangeTracker.Entries<RuvEpisode>().ToList())
@@ -29,6 +31,11 @@ public sealed class RuvarrDbContext(DbContextOptions<RuvarrDbContext> options, I
         }
 
         foreach (EntityEntry<RuvProgram> entry in ChangeTracker.Entries<RuvProgram>().ToList())
+        {
+            entry.Entity.ClearDomainEvents();
+        }
+
+        foreach (EntityEntry<DownloadQueueItem> entry in ChangeTracker.Entries<DownloadQueueItem>().ToList())
         {
             entry.Entity.ClearDomainEvents();
         }

--- a/tests/Ruvarr.UnitTests/Downloads/Domain/DownloadQueueItemTests/DomainEvents.cs
+++ b/tests/Ruvarr.UnitTests/Downloads/Domain/DownloadQueueItemTests/DomainEvents.cs
@@ -1,0 +1,52 @@
+using Ruvarr.Downloads.Domain;
+using Ruvarr.Downloads.Events;
+using Ruvarr.Testing.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Downloads.Domain.DownloadQueueItemTests;
+
+public sealed class DomainEvents
+{
+    [Fact]
+    public void MarkDownloading_RaisesDownloadStartedEvent()
+    {
+        // Arrange
+        DownloadQueueItem sut = DownloadQueueItem.Create(new RuvEpisodeBuilder().Build());
+
+        // Act
+        sut.MarkDownloading();
+
+        // Assert
+        DownloadStartedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<DownloadStartedEvent>();
+        @event.Item.ShouldBe(sut);
+    }
+
+    [Fact]
+    public void MarkDownloaded_RaisesDownloadCompletedEvent()
+    {
+        // Arrange
+        DownloadQueueItem sut = DownloadQueueItem.Create(new RuvEpisodeBuilder().Build());
+
+        // Act
+        sut.MarkDownloaded();
+
+        // Assert
+        DownloadCompletedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<DownloadCompletedEvent>();
+        @event.Item.ShouldBe(sut);
+    }
+
+    [Fact]
+    public void ClearDomainEvents_ClearsAllEvents()
+    {
+        // Arrange
+        DownloadQueueItem sut = DownloadQueueItem.Create(new RuvEpisodeBuilder().Build());
+        sut.MarkDownloading();
+
+        // Act
+        sut.ClearDomainEvents();
+
+        // Assert
+        sut.DomainEvents.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- Raise `DownloadStartedEvent` from `MarkDownloading()` and `DownloadCompletedEvent` from `MarkDownloaded()` on `DownloadQueueItem`
- Move `DownloadQueueNotifier.Notify()` calls into dedicated event handlers
- Extend `RuvarrDbContext.SaveChangesAsync()` to collect and dispatch domain events from `DownloadQueueItem`
- Remove direct `DownloadQueueNotifier` dependency from `DownloadQueueProcessor`

## Test plan
- [x] Unit tests for `MarkDownloading` raising `DownloadStartedEvent`
- [x] Unit tests for `MarkDownloaded` raising `DownloadCompletedEvent`
- [x] All 349 tests passing (323 unit + 26 integration)
- [x] Security review: no issues found
- [x] Performance review: no issues found

Closes #129