### PR TITLE
Raise domain event from RuvEpisode.ScheduleLookup()

### DIFF
--- a/src/Ruvarr/Programs/Domain/RuvEpisode.cs
+++ b/src/Ruvarr/Programs/Domain/RuvEpisode.cs
@@ -153,6 +153,7 @@ internal sealed partial class RuvEpisode
             return;
         }
 
+        _domainEvents.Add(new EpisodeLookupScheduledEvent(this));
         LookupCount++;
         NextLookup = LookupSchedule.ComputeNextLookup(LookupCount);
     }

--- a/src/Ruvarr/Programs/Events/EpisodeLookupScheduledEvent.cs
+++ b/src/Ruvarr/Programs/Events/EpisodeLookupScheduledEvent.cs
@@ -1,0 +1,6 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Programs.Domain;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed record EpisodeLookupScheduledEvent(RuvEpisode Episode) : IDomainEvent;

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/DomainEvents.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/DomainEvents.cs
@@ -108,4 +108,49 @@ public sealed class DomainEvents
         EpisodeMatchedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<EpisodeMatchedEvent>();
         @event.Episode.ShouldBe(sut);
     }
+
+    [Fact]
+    public void ScheduleLookup_RaisesEpisodeLookupScheduledEvent()
+    {
+        // Arrange
+        RuvEpisode sut = new RuvEpisodeBuilder().Build();
+
+        // Act
+        sut.ScheduleLookup();
+
+        // Assert
+        EpisodeLookupScheduledEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<EpisodeLookupScheduledEvent>();
+        @event.Episode.ShouldBe(sut);
+    }
+
+    [Fact]
+    public void ScheduleLookup_WhenAlreadyMatched_DoesNotRaiseEvent()
+    {
+        // Arrange
+        RuvEpisode sut = new RuvEpisodeBuilder().Build();
+        sut.Match(tvdbId: 1, season: 1, episode: 1, isMissing: false);
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.ScheduleLookup();
+
+        // Assert
+        sut.DomainEvents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ScheduleLookup_OnSuccessiveCalls_RaisesEventEachTime()
+    {
+        // Arrange
+        RuvEpisode sut = new RuvEpisodeBuilder().Build();
+
+        // Act
+        sut.ScheduleLookup();
+        sut.ScheduleLookup();
+        sut.ScheduleLookup();
+
+        // Assert
+        sut.DomainEvents.Count.ShouldBe(3);
+        sut.DomainEvents.ShouldAllBe(e => e is EpisodeLookupScheduledEvent);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `EpisodeLookupScheduledEvent` domain event raised from `RuvEpisode.ScheduleLookup()` when a lookup is actually scheduled (TvdbId is null)
- Event follows established pattern: `internal sealed record` implementing `IDomainEvent`
- No event handler required — only the event and raising it

## Test plan
- [x] `ScheduleLookup_RaisesEpisodeLookupScheduledEvent` — verifies event raised on unmatched episode
- [x] `ScheduleLookup_WhenAlreadyMatched_DoesNotRaiseEvent` — verifies no event when already matched
- [x] `ScheduleLookup_OnSuccessiveCalls_RaisesEventEachTime` — verifies N calls produce N events
- [x] All 352 tests pass, 0 warnings

Closes #130