### PR TITLE
chore: enable browser launch on startup

### DIFF
--- a/src/Ruvarr/Properties/launchSettings.json
+++ b/src/Ruvarr/Properties/launchSettings.json
@@ -13,7 +13,7 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
       "applicationUrl": "https://localhost:7146;http://localhost:5156",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
## Summary
- Set `launchBrowser` to `true` in the `http` launch profile so the Blazor site opens automatically when running the project.