### PR TITLE
Subscribe ProgramDetail to EpisodeMatchedEvent for live updates

### DIFF
--- a/src/Ruvarr/Programs/Events/EpisodeMatchedEventHandler.cs
+++ b/src/Ruvarr/Programs/Events/EpisodeMatchedEventHandler.cs
@@ -1,0 +1,12 @@
+using Ruvarr.Abstractions;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed class EpisodeMatchedEventHandler(IDomainEventBroadcaster broadcaster) : IDomainEventHandler<EpisodeMatchedEvent>
+{
+    public Task Handle(EpisodeMatchedEvent @event, CancellationToken cancellationToken)
+    {
+        broadcaster.Publish(@event);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Ruvarr/Programs/ProgramDetail.razor
+++ b/src/Ruvarr/Programs/ProgramDetail.razor
@@ -6,6 +6,7 @@
 @using Ruvarr.Downloads.Events
 @using Ruvarr.Downloads.Queries.GetDownloadQueue
 @using Ruvarr.ProgramRefreshQueue.Notifiers
+@using Ruvarr.Programs.Events
 @using Ruvarr.Programs.Commands.DownloadEpisode
 @using Ruvarr.Programs.Commands.RefreshProgram
 @using Ruvarr.Programs.Queries.GetProgram
@@ -202,11 +203,13 @@ else
     private readonly CancellationTokenSource _cts = new();
 
     private MatchEpisodeDialog? _matchDialog;
+    private DateTime _lastEpisodeReloadTime;
 
     protected override async Task OnInitializedAsync()
     {
         _ = WatchDownloadQueueAsync();
         _ = WatchRefreshQueueAsync();
+        _ = WatchEpisodeMatchesAsync();
 
         await using AsyncServiceScope scope = ScopeFactory.CreateAsyncScope();
         IRequestHandler<GetProgramQuery, ProgramSummary?> programHandler =
@@ -252,6 +255,32 @@ else
                 _pendingRefresh.Remove(ruvId);
             }
             await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task WatchEpisodeMatchesAsync()
+    {
+        await foreach (EpisodeMatchedEvent @event in Broadcaster.Subscribe<EpisodeMatchedEvent>(_cts.Token))
+        {
+            if (@event.Episode.Program.RuvId != RuvId)
+            {
+                continue;
+            }
+
+            if (DateTime.UtcNow - _lastEpisodeReloadTime < TimeSpan.FromMilliseconds(200))
+            {
+                continue;
+            }
+
+            await Task.Delay(200, _cts.Token);
+
+            if (DateTime.UtcNow - _lastEpisodeReloadTime < TimeSpan.FromMilliseconds(200))
+            {
+                continue;
+            }
+
+            _lastEpisodeReloadTime = DateTime.UtcNow;
+            await ReloadEpisodesAsync();
         }
     }
 

--- a/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
+++ b/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ internal static class ServiceCollectionExtensions
         services.AddTransient<IDomainEventHandler<ProgramCreatedEvent>, ProgramCreatedEventHandler>();
         services.AddTransient<IDomainEventHandler<ProgramMatchedTvdbEvent>, ProgramMatchedTvdbEventHandler>();
         services.AddTransient<IDomainEventHandler<EpisodeAddedToMatchedProgramEvent>, EpisodeAddedToMatchedProgramEventHandler>();
+        services.AddTransient<IDomainEventHandler<EpisodeMatchedEvent>, EpisodeMatchedEventHandler>();
         services.AddTransient<IRequestHandler<GetProgramQuery, ProgramSummary?>, GetProgramHandler>();
         services.AddTransient<IStreamingRequestHandler<GetProgramsQuery, ProgramSummary>, GetProgramsHandler>();
         services.AddTransient<IRequestHandler<GetProgramEpisodesQuery, List<EpisodeSummary>>, GetProgramEpisodesHandler>();

--- a/tests/Ruvarr.UnitTests/Programs/EpisodeMatchedEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/EpisodeMatchedEventHandlerTests/Handle.cs
@@ -1,0 +1,43 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Programs.Domain;
+using Ruvarr.Programs.Events;
+using Ruvarr.Testing.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.EpisodeMatchedEventHandlerTests;
+
+public sealed class Handle
+{
+    [Fact]
+    public async Task PublishesEventViaBroadcaster()
+    {
+        // Arrange
+        DomainEventBroadcaster broadcaster = new();
+        EpisodeMatchedEventHandler sut = new(broadcaster);
+        RuvEpisode episode = new RuvEpisodeBuilder().Build();
+        EpisodeMatchedEvent @event = new(episode);
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+
+        EpisodeMatchedEvent? received = null;
+        Task watchTask = Task.Run(async () =>
+        {
+            await foreach (EpisodeMatchedEvent e in broadcaster.Subscribe<EpisodeMatchedEvent>(cts.Token))
+            {
+                received = e;
+                await cts.CancelAsync();
+            }
+        }, TestContext.Current.CancellationToken);
+
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Task.WhenAny(watchTask, Task.Delay(1000, TestContext.Current.CancellationToken));
+        received.ShouldNotBeNull();
+        received.ShouldBe(@event);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `EpisodeMatchedEventHandler` to broadcast `EpisodeMatchedEvent` via `IDomainEventBroadcaster`
- Subscribe `ProgramDetail.razor` to the event with timestamp-based debounce (200ms) to coalesce batch matches into a single reload
- Filter events by program `RuvId` so only relevant episodes trigger a reload

## Test plan
- [x] Unit test for `EpisodeMatchedEventHandler` verifies event is published via broadcaster
- [ ] Manual: open program details page, trigger background `TvdbEpisodeLookupJob` match — episode table should update without navigation
- [ ] Manual: match episode via dialog — still works without regression
- [ ] Manual: bulk match multiple episodes — single reload, no flicker

Closes #141