### PR TITLE
Backfill episode duration on re-sync

### DIFF
--- a/src/Ruvarr/Programs/Domain/RuvEpisode.cs
+++ b/src/Ruvarr/Programs/Domain/RuvEpisode.cs
@@ -149,6 +149,14 @@ internal sealed partial class RuvEpisode
 
     public void Download() => DownloadQueueItem = DownloadQueueItem.Create(this);
 
+    public void UpdateDuration(int? durationSeconds)
+    {
+        if (DurationSeconds is null && durationSeconds is not null)
+        {
+            DurationSeconds = durationSeconds;
+        }
+    }
+
     public void ScheduleLookup()
     {
         if (TvdbId is not null)

--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -147,8 +147,10 @@ internal sealed class RuvProgram
 
     public bool TryAddEpisode(string id, Uri uri, string title, string description, DateTime firstRun, int? durationSeconds = null)
     {
-        if (_episodes.Any(x => x.RuvId == id))
+        RuvEpisode? existing = _episodes.FirstOrDefault(x => x.RuvId == id);
+        if (existing is not null)
         {
+            existing.UpdateDuration(durationSeconds);
             return false;
         }
 

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/TryAddEpisode.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/TryAddEpisode.cs
@@ -99,4 +99,36 @@ public sealed class TryAddEpisode
         // Assert
         sut.DomainEvents.ShouldNotContain(e => e is EpisodeAddedToMatchedProgramEvent);
     }
+
+    [Fact]
+    public void BackfillsDurationWhenExistingEpisodeHasNullDuration()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+        sut.TryAddEpisode("ep1", new Uri("http://test.com"), "Title", "Desc", DateTime.UtcNow, durationSeconds: null);
+
+        // Act
+        bool result = sut.TryAddEpisode("ep1", new Uri("http://test.com"), "Title", "Desc", DateTime.UtcNow, durationSeconds: 2700);
+
+        // Assert
+        result.ShouldBeFalse();
+        sut.Episodes.ShouldHaveSingleItem();
+        sut.Episodes[0].DurationSeconds.ShouldBe(2700);
+    }
+
+    [Fact]
+    public void DoesNotOverwriteDurationWhenExistingEpisodeAlreadyHasDuration()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+        sut.TryAddEpisode("ep1", new Uri("http://test.com"), "Title", "Desc", DateTime.UtcNow, durationSeconds: 1800);
+
+        // Act
+        bool result = sut.TryAddEpisode("ep1", new Uri("http://test.com"), "Title", "Desc", DateTime.UtcNow, durationSeconds: 2700);
+
+        // Assert
+        result.ShouldBeFalse();
+        sut.Episodes.ShouldHaveSingleItem();
+        sut.Episodes[0].DurationSeconds.ShouldBe(1800);
+    }
 }


### PR DESCRIPTION
## Summary
- Episodes created before #66 have NULL `duration_seconds`. `TryAddEpisode` now calls `UpdateDuration` on existing episodes to backfill the value when the RUV API provides it, without overwriting already-set values.
- Added `UpdateDuration` behaviour method on `RuvEpisode` with null-guard
- Two unit tests covering backfill and no-overwrite scenarios

Closes #144

## Test plan
- [x] Unit test: existing episode with null duration gets updated
- [x] Unit test: existing episode with non-null duration is not overwritten
- [ ] Verify build passes with zero warnings