### PR TITLE
feat: add priority enqueue for manual program refresh

### DIFF
--- a/src/Ruvarr/Abstractions/QueueNotifier.cs
+++ b/src/Ruvarr/Abstractions/QueueNotifier.cs
@@ -1,5 +1,3 @@
-using System.Threading.Channels;
-
 using Ruvarr.Contracts;
 
 namespace Ruvarr.Abstractions;
@@ -7,9 +5,9 @@ namespace Ruvarr.Abstractions;
 public abstract class QueueNotifier<TItem> where TItem : notnull, IQueueItemSummary
 {
     private readonly Lock _lock = new();
-    private readonly Dictionary<int, (TItem Item, int Sequence)> _items = [];
-    private readonly Channel<int> _channel = Channel.CreateUnbounded<int>();
-    private int _nextSequence;
+    private readonly Dictionary<int, (TItem Item, LinkedListNode<int> Node)> _items = [];
+    private readonly LinkedList<int> _order = new();
+    private readonly HashSet<int> _read = [];
 
     public void Enqueue(int ruvId, string programName)
     {
@@ -20,19 +18,41 @@ public abstract class QueueNotifier<TItem> where TItem : notnull, IQueueItemSumm
                 return;
             }
 
-            _items[ruvId] = (CreatePending(ruvId, programName), _nextSequence++);
+            LinkedListNode<int> node = _order.AddLast(ruvId);
+            _items[ruvId] = (CreatePending(ruvId, programName), node);
         }
+    }
 
-        _channel.Writer.TryWrite(ruvId);
+    public void PriorityEnqueue(int ruvId, string programName)
+    {
+        lock (_lock)
+        {
+            if (_items.TryGetValue(ruvId, out (TItem Item, LinkedListNode<int> Node) entry))
+            {
+                if (entry.Item.IsProcessing)
+                {
+                    return;
+                }
+
+                _order.Remove(entry.Node);
+                LinkedListNode<int> node = _order.AddFirst(ruvId);
+                _items[ruvId] = (entry.Item, node);
+                _read.Remove(ruvId);
+                return;
+            }
+
+            LinkedListNode<int> newNode = _order.AddFirst(ruvId);
+            _items[ruvId] = (CreatePending(ruvId, programName), newNode);
+        }
     }
 
     public void MarkProcessing(int ruvId)
     {
         lock (_lock)
         {
-            if (_items.TryGetValue(ruvId, out (TItem Item, int Sequence) entry))
+            if (_items.TryGetValue(ruvId, out (TItem Item, LinkedListNode<int> Node) entry))
             {
-                _items[ruvId] = (WithProcessingStatus(entry.Item), entry.Sequence);
+                _items[ruvId] = (WithProcessingStatus(entry.Item), entry.Node);
             }
         }
     }
@@ -41,7 +61,12 @@ public abstract class QueueNotifier<TItem> where TItem : notnull, IQueueItemSumm
     {
         lock (_lock)
         {
-            _items.Remove(ruvId);
+            if (_items.Remove(ruvId, out (TItem Item, LinkedListNode<int> Node) entry))
+            {
+                _order.Remove(entry.Node);
+            }
+
+            _read.Remove(ruvId);
         }
     }
 
@@ -51,10 +76,29 @@ public abstract class QueueNotifier<TItem> where TItem : notnull, IQueueItemSumm
         {
             lock (_lock)
             {
-                return [.. _items.Values
-                    .OrderBy(x => !x.Item.IsProcessing)
-                    .ThenBy(x => x.Sequence)
-                    .Select(x => x.Item)];
+                List<TItem> processing = [];
+                List<TItem> pending = [];
+
+                LinkedListNode<int>? current = _order.First;
+                while (current is not null)
+                {
+                    if (_items.TryGetValue(current.Value, out (TItem Item, LinkedListNode<int> Node) entry))
+                    {
+                        if (entry.Item.IsProcessing)
+                        {
+                            processing.Add(entry.Item);
+                        }
+                        else
+                        {
+                            pending.Add(entry.Item);
+                        }
+                    }
+
+                    current = current.Next;
+                }
+
+                processing.AddRange(pending);
+                return processing;
             }
         }
     }
@@ -63,5 +107,24 @@ public abstract class QueueNotifier<TItem> where TItem : notnull, IQueueItemSumm
 
     protected abstract TItem WithProcessingStatus(TItem item);
 
-    protected bool TryReadNext(out int ruvId) => _channel.Reader.TryRead(out ruvId);
+    protected bool TryReadNext(out int ruvId)
+    {
+        lock (_lock)
+        {
+            LinkedListNode<int>? current = _order.First;
+            while (current is not null)
+            {
+                if (_items.ContainsKey(current.Value) && _read.Add(current.Value))
+                {
+                    ruvId = current.Value;
+                    return true;
+                }
+
+                current = current.Next;
+            }
+
+            ruvId = default;
+            return false;
+        }
+    }
 }

--- a/src/Ruvarr/Programs/Commands/RefreshProgram/RefreshProgramHandler.cs
+++ b/src/Ruvarr/Programs/Commands/RefreshProgram/RefreshProgramHandler.cs
@@ -5,6 +5,7 @@ using Ruvarr.Contracts;
 using Ruvarr.ProgramRefreshQueue.Notifiers;
 using Ruvarr.Programs.Domain;
 using Ruvarr.TvdbEpisodeLookup.Notifiers;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 
 namespace Ruvarr.Programs.Commands.RefreshProgram;
 
@@ -12,6 +13,7 @@ internal sealed class RefreshProgramHandler(
     RuvarrDbContext dbContext,
     ProgramRefreshNotifier syncQueue,
     TvdbEpisodeLookupNotifier tvdbEpisodeLookupNotifier,
+    TvdbSeriesLookupNotifier tvdbSeriesLookupNotifier,
     IDomainEventBroadcaster broadcaster)
     : IRequestHandler<RefreshProgramCommand>
 {
@@ -27,12 +29,18 @@ internal sealed class RefreshProgramHandler(
             return ProgramErrors.ProgramNotFound;
         }
 
-        syncQueue.Enqueue(program.RuvId, program.Name);
+        syncQueue.PriorityEnqueue(program.RuvId, program.Name);
         broadcaster.Publish(new QueueChangedEvent<ProgramRefreshQueueItemSummary>());
+
+        if (program.Series is null)
+        {
+            tvdbSeriesLookupNotifier.PriorityEnqueue(program.RuvId, program.Name);
+            broadcaster.Publish(new QueueChangedEvent<TvdbSeriesLookupQueueItemSummary>());
+        }
 
         if (program.Series is not null && program.HasMultipleEpisodes)
         {
-            tvdbEpisodeLookupNotifier.Enqueue(program.RuvId, program.Name);
+            tvdbEpisodeLookupNotifier.PriorityEnqueue(program.RuvId, program.Name);
             broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
         }
 

--- a/tests/Ruvarr.UnitTests/Programs/Commands/RefreshProgramHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Commands/RefreshProgramHandlerTests/Handle.cs
@@ -3,11 +3,13 @@ using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 
 using Ruvarr.Abstractions;
+using Ruvarr.Contracts;
 using Ruvarr.ProgramRefreshQueue.Notifiers;
 using Ruvarr.Programs;
 using Ruvarr.Programs.Commands.RefreshProgram;
 using Ruvarr.Programs.Domain;
 using Ruvarr.TvdbEpisodeLookup.Notifiers;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
 using Ruvarr.Testing.Builders;
 
 using Shouldly;
@@ -17,6 +19,7 @@ namespace Ruvarr.UnitTests.Programs.Commands.RefreshProgramHandlerTests;
 public sealed class Handle
 {
     private readonly TvdbEpisodeLookupNotifier _tvdbEpisodeLookupNotifier = new();
+    private readonly TvdbSeriesLookupNotifier _tvdbSeriesLookupNotifier = new();
     private readonly ProgramRefreshNotifier _programRefreshNotifier = new();
     private readonly DomainEventBroadcaster _broadcaster = new();
     private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
@@ -33,7 +36,7 @@ public sealed class Handle
         _serviceProvider);
 
     private RefreshProgramHandler CreateHandler(RuvarrDbContext dbContext) => new(
-        dbContext, _programRefreshNotifier, _tvdbEpisodeLookupNotifier, _broadcaster);
+        dbContext, _programRefreshNotifier, _tvdbEpisodeLookupNotifier, _tvdbSeriesLookupNotifier, _broadcaster);
 
     [Fact]
     public async Task ReturnsProgramNotFoundWhenProgramDoesNotExist()
@@ -51,7 +54,7 @@ public sealed class Handle
     }
 
     [Fact]
-    public async Task DoesNotEnqueueWhenProgramHasNoSeries()
+    public async Task DoesNotEnqueueEpisodeLookupWhenProgramHasNoSeries()
     {
         // Arrange
         using RuvarrDbContext dbContext = CreateDbContext();
@@ -68,7 +71,7 @@ public sealed class Handle
     }
 
     [Fact]
-    public async Task DoesNotEnqueueWhenProgramHasSingleEpisode()
+    public async Task DoesNotEnqueueEpisodeLookupWhenProgramHasSingleEpisode()
     {
         // Arrange
         using RuvarrDbContext dbContext = CreateDbContext();
@@ -110,5 +113,87 @@ public sealed class Handle
         _tvdbEpisodeLookupNotifier.Items.ShouldNotBeEmpty();
         program.Episodes[0].LookupCount.ShouldBe(episodeLookupCountBefore);
         program.Episodes[0].NextLookup.ShouldBe(episodeNextLookupBefore);
+    }
+
+    [Fact]
+    public async Task PriorityEnqueuesProgramRefresh()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram existingProgram = new RuvProgramBuilder().WithRuvId(10).WithName("Existing").Build();
+        RuvProgram targetProgram = new RuvProgramBuilder().WithRuvId(1).WithName("Target").Build();
+        dbContext.Set<RuvProgram>().AddRange(existingProgram, targetProgram);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+        _programRefreshNotifier.Enqueue(10, "Existing");
+        RefreshProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
+
+        // Assert
+        IReadOnlyList<ProgramRefreshQueueItemSummary> items = _programRefreshNotifier.Items;
+        items.Count.ShouldBe(2);
+        items[0].RuvId.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task PriorityEnqueuesSeriesLookupWhenProgramHasNoSeries()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithMultipleEpisodes().Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+        RefreshProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
+
+        // Assert
+        _tvdbSeriesLookupNotifier.Items.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task DoesNotEnqueueSeriesLookupWhenProgramHasSeries()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        TvdbSeries series = new TvdbSeriesBuilder().Build();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithMultipleEpisodes().Build();
+        program.MatchTvdb(series);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+        RefreshProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
+
+        // Assert
+        _tvdbSeriesLookupNotifier.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task PriorityEnqueuesEpisodeLookup()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        TvdbSeries series = new TvdbSeriesBuilder().Build();
+        RuvProgram existingProgram = new RuvProgramBuilder().WithRuvId(10).WithName("Existing").WithMultipleEpisodes().Build();
+        existingProgram.MatchTvdb(new TvdbSeriesBuilder().Build());
+        RuvProgram targetProgram = new RuvProgramBuilder().WithRuvId(1).WithName("Target").WithMultipleEpisodes().Build();
+        targetProgram.TryAddEpisode("ep0001", new Uri("http://test.com"), "Episode 1", "", DateTime.UtcNow);
+        targetProgram.MatchTvdb(series);
+        dbContext.Set<RuvProgram>().AddRange(existingProgram, targetProgram);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+        _tvdbEpisodeLookupNotifier.Enqueue(10, "Existing");
+        RefreshProgramHandler sut = CreateHandler(dbContext);
+
+        // Act
+        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
+
+        // Assert
+        IReadOnlyList<TvdbEpisodeLookupQueueItemSummary> items = _tvdbEpisodeLookupNotifier.Items;
+        items.Count.ShouldBe(2);
+        items[0].RuvId.ShouldBe(1);
     }
 }

--- a/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/PriorityEnqueue.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramRefreshNotifierTests/PriorityEnqueue.cs
@@ -1,0 +1,119 @@
+using Ruvarr.Contracts;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.ProgramRefreshNotifierTests;
+
+public sealed class PriorityEnqueue
+{
+    [Fact]
+    public void PlacesItemAtFrontOfItems()
+    {
+        // Arrange
+        ProgramRefreshNotifier sut = new();
+        sut.Enqueue(1, "Program A");
+        sut.Enqueue(2, "Program B");
+
+        // Act
+        sut.PriorityEnqueue(3, "Program C");
+
+        // Assert
+        IReadOnlyList<ProgramRefreshQueueItemSummary> items = sut.Items;
+        items.Count.ShouldBe(3);
+        items[0].RuvId.ShouldBe(3);
+        items[1].RuvId.ShouldBe(1);
+        items[2].RuvId.ShouldBe(2);
+    }
+
+    [Fact]
+    public void MovesExistingQueuedItemToFront()
+    {
+        // Arrange
+        ProgramRefreshNotifier sut = new();
+        sut.Enqueue(1, "Program A");
+        sut.Enqueue(2, "Program B");
+        sut.Enqueue(3, "Program C");
+
+        // Act
+        sut.PriorityEnqueue(3, "Program C");
+
+        // Assert
+        IReadOnlyList<ProgramRefreshQueueItemSummary> items = sut.Items;
+        items.Count.ShouldBe(3);
+        items[0].RuvId.ShouldBe(3);
+        items[1].RuvId.ShouldBe(1);
+        items[2].RuvId.ShouldBe(2);
+    }
+
+    [Fact]
+    public void IsNoOpForItemInProcessingState()
+    {
+        // Arrange
+        ProgramRefreshNotifier sut = new();
+        sut.Enqueue(1, "Program A");
+        sut.Enqueue(2, "Program B");
+        List<int> _ = sut.DequeueAll().ToList();
+        sut.MarkProcessing(2);
+
+        // Act
+        sut.PriorityEnqueue(2, "Program B");
+
+        // Assert
+        IReadOnlyList<ProgramRefreshQueueItemSummary> items = sut.Items;
+        items.Count.ShouldBe(2);
+        items[0].RuvId.ShouldBe(2);
+        items[0].Status.ShouldBe(ProgramRefreshStatus.Processing);
+    }
+
+    [Fact]
+    public void StandardEnqueueIsNoOpForPriorityQueuedItem()
+    {
+        // Arrange
+        ProgramRefreshNotifier sut = new();
+        sut.PriorityEnqueue(1, "Program A");
+
+        // Act
+        sut.Enqueue(1, "Program A");
+
+        // Assert
+        IReadOnlyList<ProgramRefreshQueueItemSummary> items = sut.Items;
+        items.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void ClearsReadFlagSoItemCanBeReadAgain()
+    {
+        // Arrange
+        ProgramRefreshNotifier sut = new();
+        sut.Enqueue(1, "Program A");
+        List<int> firstRead = sut.DequeueAll().ToList();
+        firstRead.ShouldHaveSingleItem();
+
+        // Act
+        sut.PriorityEnqueue(1, "Program A");
+
+        // Assert
+        List<int> secondRead = sut.DequeueAll().ToList();
+        secondRead.ShouldHaveSingleItem();
+        secondRead[0].ShouldBe(1);
+    }
+
+    [Fact]
+    public void DequeueOrderRespectsPriority()
+    {
+        // Arrange
+        ProgramRefreshNotifier sut = new();
+        sut.Enqueue(1, "Program A");
+        sut.Enqueue(2, "Program B");
+        sut.PriorityEnqueue(3, "Program C");
+
+        // Act
+        List<int> dequeued = sut.DequeueAll().ToList();
+
+        // Assert
+        dequeued[0].ShouldBe(3);
+        dequeued[1].ShouldBe(1);
+        dequeued[2].ShouldBe(2);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `Channel<int>` with `LinkedList<int>` + `HashSet<int>` in `QueueNotifier` to support front-of-queue insertion via new `PriorityEnqueue` method
- Manual refresh now calls `PriorityEnqueue` on all relevant notifiers (ProgramRefreshNotifier, TvdbEpisodeLookupNotifier, and conditionally TvdbSeriesLookupNotifier when program has no matched series)
- `Items` property returns actual processing order (linked list traversal) instead of sequence-based ordering

## Test plan
- [x] PriorityEnqueue places item at front of Items
- [x] PriorityEnqueue moves existing queued item to front
- [x] PriorityEnqueue is no-op for item in Processing state
- [x] Standard Enqueue for already-priority-queued item is no-op
- [x] Dequeue order respects priority
- [x] PriorityEnqueue clears read flag so item can be re-read
- [x] Handler priority-enqueues into ProgramRefreshNotifier
- [x] Handler priority-enqueues into TvdbSeriesLookupNotifier when no series
- [x] Handler does not enqueue series lookup when series exists
- [x] Handler priority-enqueues into TvdbEpisodeLookupNotifier
- [x] All 374 existing tests pass

Closes #91