### PR TITLE
Persist search text across navigation

### DIFF
--- a/src/Ruvarr/Programs/Programs.razor
+++ b/src/Ruvarr/Programs/Programs.razor
@@ -49,7 +49,7 @@
 </div>
 
 <div class="search-bar">
-    <input type="text" placeholder="Search programs..." @bind="_searchText" @bind:event="oninput" />
+    <input type="text" placeholder="Search programs..." @bind="FilterState.SearchText" @bind:event="oninput" />
 </div>
 
 @if (_programs is null)
@@ -59,12 +59,18 @@
 else
 {
     List<ProgramSummary> visibleList = [.. _programs
-        .Where(p => string.IsNullOrWhiteSpace(_searchText) || p.ProgramName.Contains(_searchText, StringComparison.OrdinalIgnoreCase))
+        .Where(p => string.IsNullOrWhiteSpace(FilterState.SearchText) || p.ProgramName.Contains(FilterState.SearchText, StringComparison.OrdinalIgnoreCase))
         .Where(p => string.IsNullOrEmpty(FilterState.FilterChannel) || p.Channel == FilterState.FilterChannel)];
 
     if (visibleList.Count == 0)
     {
-        <p class="empty-message">@(FilterState.HasActiveFilters ? "No programs match the selected filters." : "No programs found.")</p>
+        <p class="empty-message">@((FilterState.HasActiveFilters, FilterState.HasSearchText) switch
+        {
+            (true, true) => "No programs match the selected filters and search.",
+            (false, true) => "No programs match your search.",
+            (true, false) => "No programs match the selected filters.",
+            _ => "No programs found."
+        })</p>
     }
     else
     {
@@ -209,7 +215,6 @@ else
 
     private MatchProgramDialog? _matchProgramDialog;
     private List<ProgramSummary>? _programs;
-    private string _searchText = string.Empty;
     private readonly HashSet<int> _pendingRefresh = [];
     private Dictionary<int, ProgramRefreshStatus> _refreshQueue = [];
     private readonly CancellationTokenSource _cts = new();

--- a/src/Ruvarr/Programs/ProgramsFilterState.cs
+++ b/src/Ruvarr/Programs/ProgramsFilterState.cs
@@ -8,6 +8,9 @@ internal sealed class ProgramsFilterState
     public bool FilterPartiallyMatched { get; set; }
     public bool FilterMonitored { get; set; }
     public string FilterChannel { get; set; } = string.Empty;
+    public string SearchText { get; set; } = string.Empty;
+
+    public bool HasSearchText => !string.IsNullOrWhiteSpace(SearchText);
 
     public bool HasActiveFilters =>
         FilterUnmatchedPrograms ||

--- a/tests/Ruvarr.UnitTests/Programs/ProgramsFilterStateTests/Clear.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramsFilterStateTests/Clear.cs
@@ -32,4 +32,17 @@ public sealed class Clear
         sut.FilterMonitored.ShouldBeFalse();
         sut.FilterChannel.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void DoesNotResetSearchText()
+    {
+        // Arrange
+        ProgramsFilterState sut = new() { SearchText = "test query" };
+
+        // Act
+        sut.Clear();
+
+        // Assert
+        sut.SearchText.ShouldBe("test query");
+    }
 }

--- a/tests/Ruvarr.UnitTests/Programs/ProgramsFilterStateTests/HasActiveFilters.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramsFilterStateTests/HasActiveFilters.cs
@@ -96,4 +96,17 @@ public sealed class HasActiveFilters
         // Assert
         result.ShouldBeTrue();
     }
+
+    [Fact]
+    public void ReturnsFalseWhenOnlySearchTextIsSet()
+    {
+        // Arrange
+        ProgramsFilterState sut = new() { SearchText = "test" };
+
+        // Act
+        bool result = sut.HasActiveFilters;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
 }

--- a/tests/Ruvarr.UnitTests/Programs/ProgramsFilterStateTests/HasSearchText.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramsFilterStateTests/HasSearchText.cs
@@ -1,0 +1,47 @@
+using Ruvarr.Programs;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.ProgramsFilterStateTests;
+
+public sealed class HasSearchText
+{
+    [Fact]
+    public void ReturnsFalseByDefault()
+    {
+        // Arrange
+        ProgramsFilterState sut = new();
+
+        // Act
+        bool result = sut.HasSearchText;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrueWhenSearchTextIsNonEmpty()
+    {
+        // Arrange
+        ProgramsFilterState sut = new() { SearchText = "test" };
+
+        // Act
+        bool result = sut.HasSearchText;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ReturnsFalseWhenSearchTextIsWhitespaceOnly()
+    {
+        // Arrange
+        ProgramsFilterState sut = new() { SearchText = "   " };
+
+        // Act
+        bool result = sut.HasSearchText;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Move search text from component-local `_searchText` field to `ProgramsFilterState` scoped service so it persists across navigation within the Blazor circuit
- Add `HasSearchText` computed property for contextual empty-state messages
- `Clear()` does not reset search text (search is independent of filters)
- Empty-state messages now distinguish filter-only, search-only, combined, and no-filter scenarios

Closes #95

## Test plan
- [x] Unit tests for `HasSearchText` (default false, true when non-empty, false for whitespace)
- [x] Unit test verifying `Clear()` preserves `SearchText`
- [x] Unit test verifying `HasActiveFilters` excludes `SearchText`
- [ ] Manual: type search term, navigate to detail page and back — search text restored
- [ ] Manual: reload browser tab — search text cleared
- [ ] Manual: two tabs maintain independent search state