### PR TITLE
Skip TVDB series match when year-suffixed variant exists

### DIFF
--- a/src/Ruvarr/Extensions/StringExtensions.cs
+++ b/src/Ruvarr/Extensions/StringExtensions.cs
@@ -47,6 +47,22 @@ internal static partial class StringExtensions
     // https://en.wikipedia.org/wiki/Soft_hyphen
     private static string RemoveSoftHyphens(this string input) => input.Replace("\u00AD", string.Empty, StringComparison.OrdinalIgnoreCase);
 
+    internal static bool HasYearSuffix(this string? input) =>
+        !string.IsNullOrWhiteSpace(input) && YearSuffixRegex().IsMatch(input);
+
+    internal static string? WithoutYearSuffix(this string? input)
+    {
+        if (!input.HasYearSuffix())
+        {
+            return input;
+        }
+
+        return YearSuffixRegex().Replace(input!, string.Empty).Trim();
+    }
+
+    [GeneratedRegex(@"\(\d{4}\)\s*$")]
+    private static partial Regex YearSuffixRegex();
+
     [GeneratedRegex(@"[^\p{L}\p{N}]")]
     private static partial Regex NonUnicodeCharactersRegex();
 

--- a/src/Ruvarr/TvdbSeriesLookup/Jobs/TvdbSeriesLookupJob.cs
+++ b/src/Ruvarr/TvdbSeriesLookup/Jobs/TvdbSeriesLookupJob.cs
@@ -120,6 +120,10 @@ internal sealed class TvdbSeriesLookupJob(
         _ = await dbContext.SaveChangesAsync(cancellationToken);
     }
 
+    private static bool HasYearSuffixedVariant(List<Datum> data, string searchText) => data.Any(d =>
+        (d.Name.HasYearSuffix() && d.Name.WithoutYearSuffix()!.EqualsSanitized(searchText))
+        || (d.Translations.TryGetValue("isl", out string? islName) && islName.HasYearSuffix() && islName.WithoutYearSuffix()!.EqualsSanitized(searchText)));
+
     private Task<Datum?> TryRemovingNumeralEnding(string? searchText, bool checkTranslations)
     {
         string? trimmed = searchText.WithoutNumeralEnding();
@@ -161,6 +165,12 @@ internal sealed class TvdbSeriesLookupJob(
         }
 
         logger.LogDebug("Tvdb returned '{Count}' exact match(es) for series {Name}", matches.Count, searchText);
+
+        if (matches.Count == 1 && HasYearSuffixedVariant(data, searchText))
+        {
+            logger.LogDebug("Skipping ambiguous match for '{Name}' — year-suffixed variant exists in TVDB results", searchText);
+            return null;
+        }
 
         return matches.Count == 1 ? matches[0] : null;
     }

--- a/tests/Ruvarr.Testing/Builders/DatumBuilder.cs
+++ b/tests/Ruvarr.Testing/Builders/DatumBuilder.cs
@@ -1,0 +1,47 @@
+using Ruvarr.Infrastructure.Tvdb.Models;
+
+namespace Ruvarr.Testing.Builders;
+
+internal sealed class DatumBuilder
+{
+    private string _name = "Test Series";
+    private string _tvdbId = "1000";
+    private string _type = "series";
+    private string _slug = "test-series";
+    private IReadOnlyDictionary<string, string> _translations = new Dictionary<string, string>();
+
+    public DatumBuilder WithName(string name) { _name = name; return this; }
+
+    public DatumBuilder WithTvdbId(string tvdbId) { _tvdbId = tvdbId; return this; }
+
+    public DatumBuilder WithType(string type) { _type = type; return this; }
+
+    public DatumBuilder WithSlug(string slug) { _slug = slug; return this; }
+
+    public DatumBuilder WithTranslations(IReadOnlyDictionary<string, string> translations)
+    {
+        _translations = translations;
+        return this;
+    }
+
+    public Datum Build() => new(
+        ObjectId: "series-1000",
+        Aliases: [],
+        Country: "IS",
+        Id: _tvdbId,
+        ImageUrl: new Uri("http://image.com"),
+        Name: _name,
+        FirstAirDate: "2024-01-01",
+        Overview: "",
+        PrimaryLanguage: "isl",
+        PrimaryType: "series",
+        Status: "Continuing",
+        Type: _type,
+        TvdbId: _tvdbId,
+        Year: "2024",
+        Slug: _slug,
+        Overviews: new Dictionary<string, string>(),
+        Translations: _translations,
+        Network: "",
+        RemoteIds: []);
+}

--- a/tests/Ruvarr.UnitTests/Extensions/StringExtensionTests/HasYearSuffix.cs
+++ b/tests/Ruvarr.UnitTests/Extensions/StringExtensionTests/HasYearSuffix.cs
@@ -1,0 +1,55 @@
+using Ruvarr.Extensions;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Extensions.StringExtensionTests;
+
+public sealed class HasYearSuffix
+{
+    [Theory]
+    [InlineData("Katla (2021)")]
+    [InlineData("Trapped (2015)")]
+    [InlineData("The Show (1999)")]
+    [InlineData("Name (2021) ")]
+    public void ReturnsTrue_WhenStringEndsWithYearInParentheses(string value)
+    {
+        // Arrange
+
+        // Act
+        bool result = value.HasYearSuffix();
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("Katla")]
+    [InlineData("Trapped")]
+    [InlineData("The Show (documentary)")]
+    [InlineData("Name (12)")]
+    [InlineData("Name (20210)")]
+    [InlineData("")]
+    public void ReturnsFalse_WhenStringDoesNotEndWithYearInParentheses(string value)
+    {
+        // Arrange
+
+        // Act
+        bool result = value.HasYearSuffix();
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenStringIsNull()
+    {
+        // Arrange
+        string? value = null;
+
+        // Act
+        bool result = value.HasYearSuffix();
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/tests/Ruvarr.UnitTests/Extensions/StringExtensionTests/WithoutYearSuffix.cs
+++ b/tests/Ruvarr.UnitTests/Extensions/StringExtensionTests/WithoutYearSuffix.cs
@@ -1,0 +1,52 @@
+using Ruvarr.Extensions;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Extensions.StringExtensionTests;
+
+public sealed class WithoutYearSuffix
+{
+    [Theory]
+    [InlineData("Katla (2021)", "Katla")]
+    [InlineData("Trapped (2015)", "Trapped")]
+    [InlineData("The Show (1999)", "The Show")]
+    [InlineData("Name (2021) ", "Name")]
+    public void ReturnsTrimmedBaseName_WhenStringEndsWithYearInParentheses(string value, string expected)
+    {
+        // Arrange
+
+        // Act
+        string? result = value.WithoutYearSuffix();
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("Katla")]
+    [InlineData("The Show (documentary)")]
+    [InlineData("")]
+    public void ReturnsOriginalValue_WhenStringDoesNotEndWithYearInParentheses(string value)
+    {
+        // Arrange
+
+        // Act
+        string? result = value.WithoutYearSuffix();
+
+        // Assert
+        result.ShouldBe(value);
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenStringIsNull()
+    {
+        // Arrange
+        string? value = null;
+
+        // Act
+        string? result = value.WithoutYearSuffix();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+}

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbSeriesLookupJobTests/SearchTvdbAsync.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbSeriesLookupJobTests/SearchTvdbAsync.cs
@@ -1,0 +1,306 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+
+using Quartz;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Infrastructure.Tvdb;
+using Ruvarr.Infrastructure.Tvdb.Models;
+using Ruvarr.Programs.Domain;
+using Ruvarr.Testing.Builders;
+using Ruvarr.TvdbSeriesLookup.Jobs;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Jobs.TvdbSeriesLookupJobTests;
+
+public sealed class SearchTvdbAsync
+{
+    private readonly ITvdbClient _tvdb = Substitute.For<ITvdbClient>();
+    private readonly TvdbSeriesLookupNotifier _lookupQueue = new();
+    private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
+    private readonly IJobExecutionContext _context = Substitute.For<IJobExecutionContext>();
+
+    public SearchTvdbAsync()
+    {
+        _serviceProvider.GetService(Arg.Any<Type>()).Returns(Array.Empty<object>());
+        _context.CancellationToken.Returns(CancellationToken.None);
+    }
+
+    private RuvarrDbContext CreateDbContext() => new(
+        new DbContextOptionsBuilder<RuvarrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options,
+        _serviceProvider);
+
+    private TvdbSeriesLookupJob CreateJob(RuvarrDbContext dbContext) => new(
+        NullLogger<TvdbSeriesLookupJob>.Instance,
+        dbContext,
+        _tvdb,
+        _lookupQueue,
+        new DomainEventBroadcaster());
+
+    private static SearchResponse CreateSearchResponse(params Datum[] data) => new(
+        Status: "success",
+        Data: data,
+        Links: new Links(
+            Prev: null,
+            Self: new Uri("http://test.com"),
+            Next: null,
+            TotalItems: data.Length,
+            PageSize: 100));
+
+    [Fact]
+    public async Task ReturnsNull_WhenSingleMatch_AndYearSuffixedVariantExistsInName()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Katla")
+            .WithForeignName(null)
+            .Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Datum exactMatch = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("100")
+            .Build();
+        Datum yearVariant = new DatumBuilder()
+            .WithName("Katla (2021)")
+            .WithTvdbId("200")
+            .Build();
+
+        _tvdb.SearchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(CreateSearchResponse(exactMatch, yearVariant));
+        _lookupQueue.Enqueue(1, program.Name);
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        program.Series.ShouldBeNull();
+        program.NextLookup.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task ReturnsNull_WhenSingleMatch_AndYearSuffixedVariantExistsInIcelandicTranslation()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Katla")
+            .WithForeignName(null)
+            .Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Datum exactMatch = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("100")
+            .WithTranslations(new Dictionary<string, string> { ["isl"] = "Katla" })
+            .Build();
+        Datum yearVariant = new DatumBuilder()
+            .WithName("Other Name")
+            .WithTvdbId("200")
+            .WithTranslations(new Dictionary<string, string> { ["isl"] = "Katla (2021)" })
+            .Build();
+
+        _tvdb.SearchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(CreateSearchResponse(exactMatch, yearVariant));
+        _lookupQueue.Enqueue(1, program.Name);
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        program.Series.ShouldBeNull();
+        program.NextLookup.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task ReturnsMatch_WhenSingleMatch_AndNoYearSuffixedVariantExists()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Katla")
+            .WithForeignName(null)
+            .Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Datum exactMatch = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("100")
+            .Build();
+        Datum otherSeries = new DatumBuilder()
+            .WithName("Something Else")
+            .WithTvdbId("200")
+            .Build();
+
+        _tvdb.SearchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(CreateSearchResponse(exactMatch, otherSeries));
+        _lookupQueue.Enqueue(1, program.Name);
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        program.Series.ShouldNotBeNull();
+        program.Series.TvdbId.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task ReturnsNull_WhenMultipleExactMatches_RegardlessOfYearSuffix()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Katla")
+            .WithForeignName(null)
+            .Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Datum match1 = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("100")
+            .Build();
+        Datum match2 = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("200")
+            .Build();
+
+        _tvdb.SearchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(CreateSearchResponse(match1, match2));
+        _lookupQueue.Enqueue(1, program.Name);
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        program.Series.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ReturnsNull_WhenZeroMatches_RegardlessOfYearSuffix()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Katla")
+            .WithForeignName(null)
+            .Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Datum unrelated = new DatumBuilder()
+            .WithName("Something Else")
+            .WithTvdbId("100")
+            .Build();
+
+        _tvdb.SearchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(CreateSearchResponse(unrelated));
+        _lookupQueue.Enqueue(1, program.Name);
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        program.Series.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task DoesNotFalsePositive_WhenYearSuffixedEntryBaseNameDoesNotMatch()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Katla")
+            .WithForeignName(null)
+            .Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Datum exactMatch = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("100")
+            .Build();
+        Datum differentYearVariant = new DatumBuilder()
+            .WithName("Other Show (2021)")
+            .WithTvdbId("200")
+            .Build();
+
+        _tvdb.SearchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(CreateSearchResponse(exactMatch, differentYearVariant));
+        _lookupQueue.Enqueue(1, program.Name);
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        program.Series.ShouldNotBeNull();
+        program.Series.TvdbId.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task FallsBackToForeignName_WhenIcelandicNameIsAmbiguous()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Katla")
+            .WithForeignName("Unique Foreign Name")
+            .Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Datum exactMatch = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("100")
+            .WithTranslations(new Dictionary<string, string> { ["isl"] = "Katla" })
+            .Build();
+        Datum yearVariant = new DatumBuilder()
+            .WithName("Katla (2021)")
+            .WithTvdbId("200")
+            .Build();
+
+        SearchResponse ambiguousResponse = CreateSearchResponse(exactMatch, yearVariant);
+        SearchResponse foreignResponse = CreateSearchResponse(
+            new DatumBuilder()
+                .WithName("Unique Foreign Name")
+                .WithTvdbId("300")
+                .Build());
+
+        _tvdb.SearchAsync(Arg.Is<string>(q => q.Contains("KATLA")), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(ambiguousResponse);
+        _tvdb.SearchAsync(Arg.Is<string>(q => q.Contains("UNIQUE")), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(foreignResponse);
+        _lookupQueue.Enqueue(1, program.Name);
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        program.Series.ShouldNotBeNull();
+        program.Series.TvdbId.ShouldBe(300);
+    }
+}


### PR DESCRIPTION
## Summary
- When TVDB returns both an exact match and a year-suffixed variant (e.g., "Sögur úr Andabæ" and "Sögur úr Andabæ (2017)"), the match is now skipped as ambiguous
- Added `HasYearSuffix()` and `WithoutYearSuffix()` string extension methods with `[GeneratedRegex]`
- Added `HasYearSuffixedVariant` guard clause in `SearchTvdbAsync` that checks the full `data` list

## Test plan
- [x] 6 unit tests for `HasYearSuffix` (year suffix, non-year parenthetical, null/empty)
- [x] 7 unit tests for `WithoutYearSuffix` (stripping, no-op, null/empty)
- [x] 7 unit tests for `SearchTvdbAsync` covering AC1-AC7 (exact match, ambiguous skip, Icelandic translation path, name path, non-year parenthetical, full data list check, multiple matches regression)
- [x] All 427 tests pass

Closes #116