### PR TITLE
Raise ProgramMatchedTmdbEvent from RuvProgram.MatchTmdb()

### DIFF
--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -142,6 +142,7 @@ internal sealed class RuvProgram
         NextLookup = null;
         Matched = DateTime.UtcNow;
         Movie = movie;
+        _domainEvents.Add(new ProgramMatchedTmdbEvent(RuvId, Name));
     }
 
     public void ScheduleLookup()

--- a/src/Ruvarr/Programs/Events/ProgramMatchedTmdbEvent.cs
+++ b/src/Ruvarr/Programs/Events/ProgramMatchedTmdbEvent.cs
@@ -1,0 +1,5 @@
+using Ruvarr.Abstractions;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed record ProgramMatchedTmdbEvent(int RuvId, string Name) : IDomainEvent;

--- a/src/Ruvarr/Programs/Events/ProgramMatchedTmdbEventHandler.cs
+++ b/src/Ruvarr/Programs/Events/ProgramMatchedTmdbEventHandler.cs
@@ -1,0 +1,12 @@
+using Ruvarr.Abstractions;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed class ProgramMatchedTmdbEventHandler(IDomainEventBroadcaster broadcaster) : IDomainEventHandler<ProgramMatchedTmdbEvent>
+{
+    public Task Handle(ProgramMatchedTmdbEvent @event, CancellationToken cancellationToken)
+    {
+        broadcaster.Publish(@event);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
+++ b/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ internal static class ServiceCollectionExtensions
     {
         services.AddTransient<IDomainEventHandler<ProgramCreatedEvent>, ProgramCreatedEventHandler>();
         services.AddTransient<IDomainEventHandler<ProgramMatchedTvdbEvent>, ProgramMatchedTvdbEventHandler>();
+        services.AddTransient<IDomainEventHandler<ProgramMatchedTmdbEvent>, ProgramMatchedTmdbEventHandler>();
         services.AddTransient<IDomainEventHandler<EpisodeAddedToMatchedProgramEvent>, EpisodeAddedToMatchedProgramEventHandler>();
         services.AddTransient<IDomainEventHandler<EpisodeMatchedEvent>, EpisodeMatchedEventHandler>();
         services.AddTransient<IRequestHandler<GetProgramQuery, ProgramSummary?>, GetProgramHandler>();

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/MatchTmdb.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/MatchTmdb.cs
@@ -1,4 +1,5 @@
 using Ruvarr.Programs.Domain;
+using Ruvarr.Programs.Events;
 using Ruvarr.Testing.Builders;
 
 using Shouldly;
@@ -62,5 +63,21 @@ public sealed class MatchTmdb
 
         // Assert
         sut.LookupCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RaisesProgramMatchedTmdbEvent()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().WithRuvId(42).WithName("Test Program").Build();
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.MatchTmdb(new TmdbMovieBuilder().Build());
+
+        // Assert
+        ProgramMatchedTmdbEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProgramMatchedTmdbEvent>();
+        @event.RuvId.ShouldBe(42);
+        @event.Name.ShouldBe("Test Program");
     }
 }

--- a/tests/Ruvarr.UnitTests/Programs/ProgramMatchedTmdbEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramMatchedTmdbEventHandlerTests/Handle.cs
@@ -1,0 +1,40 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Programs.Events;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.ProgramMatchedTmdbEventHandlerTests;
+
+public sealed class Handle
+{
+    [Fact]
+    public async Task BroadcastsEvent()
+    {
+        // Arrange
+        DomainEventBroadcaster broadcaster = new();
+        ProgramMatchedTmdbEventHandler sut = new(broadcaster);
+        ProgramMatchedTmdbEvent @event = new(42, "Test Program");
+
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+        ProgramMatchedTmdbEvent? received = null;
+        Task watchTask = Task.Run(async () =>
+        {
+            await foreach (ProgramMatchedTmdbEvent e in broadcaster.Subscribe<ProgramMatchedTmdbEvent>(cts.Token))
+            {
+                received = e;
+                await cts.CancelAsync();
+            }
+        }, cts.Token);
+
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Task.WhenAny(watchTask, Task.Delay(2000, TestContext.Current.CancellationToken));
+        received.ShouldNotBeNull();
+        received.RuvId.ShouldBe(42);
+        received.Name.ShouldBe("Test Program");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ProgramMatchedTmdbEvent` domain event mirroring `ProgramMatchedTvdbEvent`
- Raise it from `RuvProgram.MatchTmdb()` for symmetry with `MatchTvdb()`
- Add broadcast-only handler and register in DI

Closes #122