### PR TITLE
Replace imperative queue enqueuing in RefreshProgramHandler with domain event

### DIFF
--- a/src/Ruvarr/Programs/Commands/RefreshProgram/RefreshProgramHandler.cs
+++ b/src/Ruvarr/Programs/Commands/RefreshProgram/RefreshProgramHandler.cs
@@ -1,20 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 
 using Ruvarr.Abstractions;
-using Ruvarr.Contracts;
-using Ruvarr.ProgramRefreshQueue.Notifiers;
 using Ruvarr.Programs.Domain;
-using Ruvarr.TvdbEpisodeLookup.Notifiers;
-using Ruvarr.TvdbSeriesLookup.Notifiers;
 
 namespace Ruvarr.Programs.Commands.RefreshProgram;
 
-internal sealed class RefreshProgramHandler(
-    RuvarrDbContext dbContext,
-    ProgramRefreshNotifier syncQueue,
-    TvdbEpisodeLookupNotifier tvdbEpisodeLookupNotifier,
-    TvdbSeriesLookupNotifier tvdbSeriesLookupNotifier,
-    IDomainEventBroadcaster broadcaster)
+internal sealed class RefreshProgramHandler(RuvarrDbContext dbContext)
     : IRequestHandler<RefreshProgramCommand>
 {
     public async Task<RuvarrResult> Handle(RefreshProgramCommand command, CancellationToken cancellationToken)
@@ -29,20 +20,8 @@ internal sealed class RefreshProgramHandler(
             return ProgramErrors.ProgramNotFound;
         }
 
-        syncQueue.PriorityEnqueue(program.RuvId, program.Name);
-        broadcaster.Publish(new QueueChangedEvent<ProgramRefreshQueueItemSummary>());
-
-        if (program.Series is null)
-        {
-            tvdbSeriesLookupNotifier.PriorityEnqueue(program.RuvId, program.Name);
-            broadcaster.Publish(new QueueChangedEvent<TvdbSeriesLookupQueueItemSummary>());
-        }
-
-        if (program.Series is not null && program.HasMultipleEpisodes)
-        {
-            tvdbEpisodeLookupNotifier.PriorityEnqueue(program.RuvId, program.Name);
-            broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
-        }
+        program.RequestRefresh();
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         return RuvarrResult.Success;
     }

--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -145,6 +145,11 @@ internal sealed class RuvProgram
         _domainEvents.Add(new ProgramMatchedTmdbEvent(RuvId, Name));
     }
 
+    public void RequestRefresh()
+    {
+        _domainEvents.Add(new ProgramRefreshRequestedEvent(RuvId, Name, Series is not null, HasMultipleEpisodes));
+    }
+
     public void ScheduleLookup()
     {
         LookupCount++;

--- a/src/Ruvarr/Programs/Events/ProgramRefreshRequestedEvent.cs
+++ b/src/Ruvarr/Programs/Events/ProgramRefreshRequestedEvent.cs
@@ -1,0 +1,5 @@
+using Ruvarr.Abstractions;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed record ProgramRefreshRequestedEvent(int RuvId, string Name, bool HasSeries, bool HasMultipleEpisodes) : IDomainEvent;

--- a/src/Ruvarr/Programs/Events/ProgramRefreshRequestedEventHandler.cs
+++ b/src/Ruvarr/Programs/Events/ProgramRefreshRequestedEventHandler.cs
@@ -1,0 +1,34 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Contracts;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
+
+namespace Ruvarr.Programs.Events;
+
+internal sealed class ProgramRefreshRequestedEventHandler(
+    ProgramRefreshNotifier programRefreshNotifier,
+    TvdbSeriesLookupNotifier tvdbSeriesLookupNotifier,
+    TvdbEpisodeLookupNotifier tvdbEpisodeLookupNotifier,
+    IDomainEventBroadcaster broadcaster) : IDomainEventHandler<ProgramRefreshRequestedEvent>
+{
+    public Task Handle(ProgramRefreshRequestedEvent @event, CancellationToken cancellationToken)
+    {
+        programRefreshNotifier.PriorityEnqueue(@event.RuvId, @event.Name);
+        broadcaster.Publish(new QueueChangedEvent<ProgramRefreshQueueItemSummary>());
+
+        if (!@event.HasSeries)
+        {
+            tvdbSeriesLookupNotifier.PriorityEnqueue(@event.RuvId, @event.Name);
+            broadcaster.Publish(new QueueChangedEvent<TvdbSeriesLookupQueueItemSummary>());
+        }
+
+        if (@event.HasSeries && @event.HasMultipleEpisodes)
+        {
+            tvdbEpisodeLookupNotifier.PriorityEnqueue(@event.RuvId, @event.Name);
+            broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
+++ b/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ internal static class ServiceCollectionExtensions
         services.AddTransient<IDomainEventHandler<ProgramCreatedEvent>, ProgramCreatedEventHandler>();
         services.AddTransient<IDomainEventHandler<ProgramMatchedTvdbEvent>, ProgramMatchedTvdbEventHandler>();
         services.AddTransient<IDomainEventHandler<ProgramMatchedTmdbEvent>, ProgramMatchedTmdbEventHandler>();
+        services.AddTransient<IDomainEventHandler<ProgramRefreshRequestedEvent>, ProgramRefreshRequestedEventHandler>();
         services.AddTransient<IDomainEventHandler<EpisodeAddedToMatchedProgramEvent>, EpisodeAddedToMatchedProgramEventHandler>();
         services.AddTransient<IDomainEventHandler<EpisodeMatchedEvent>, EpisodeMatchedEventHandler>();
         services.AddTransient<IRequestHandler<GetProgramQuery, ProgramSummary?>, GetProgramHandler>();

--- a/tests/Ruvarr.UnitTests/Programs/Commands/RefreshProgramHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Commands/RefreshProgramHandlerTests/Handle.cs
@@ -3,13 +3,9 @@ using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 
 using Ruvarr.Abstractions;
-using Ruvarr.Contracts;
-using Ruvarr.ProgramRefreshQueue.Notifiers;
 using Ruvarr.Programs;
 using Ruvarr.Programs.Commands.RefreshProgram;
 using Ruvarr.Programs.Domain;
-using Ruvarr.TvdbEpisodeLookup.Notifiers;
-using Ruvarr.TvdbSeriesLookup.Notifiers;
 using Ruvarr.Testing.Builders;
 
 using Shouldly;
@@ -18,10 +14,6 @@ namespace Ruvarr.UnitTests.Programs.Commands.RefreshProgramHandlerTests;
 
 public sealed class Handle
 {
-    private readonly TvdbEpisodeLookupNotifier _tvdbEpisodeLookupNotifier = new();
-    private readonly TvdbSeriesLookupNotifier _tvdbSeriesLookupNotifier = new();
-    private readonly ProgramRefreshNotifier _programRefreshNotifier = new();
-    private readonly DomainEventBroadcaster _broadcaster = new();
     private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
 
     public Handle()
@@ -35,8 +27,7 @@ public sealed class Handle
             .Options,
         _serviceProvider);
 
-    private RefreshProgramHandler CreateHandler(RuvarrDbContext dbContext) => new(
-        dbContext, _programRefreshNotifier, _tvdbEpisodeLookupNotifier, _tvdbSeriesLookupNotifier, _broadcaster);
+    private static RefreshProgramHandler CreateHandler(RuvarrDbContext dbContext) => new(dbContext);
 
     [Fact]
     public async Task ReturnsProgramNotFoundWhenProgramDoesNotExist()
@@ -50,150 +41,22 @@ public sealed class Handle
 
         // Assert
         result.Error.ShouldBe(ProgramErrors.ProgramNotFound);
-        _tvdbEpisodeLookupNotifier.Items.ShouldBeEmpty();
     }
 
     [Fact]
-    public async Task DoesNotEnqueueEpisodeLookupWhenProgramHasNoSeries()
+    public async Task ReturnsSuccessWhenProgramExists()
     {
         // Arrange
         using RuvarrDbContext dbContext = CreateDbContext();
-        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithMultipleEpisodes().Build();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).Build();
         dbContext.Set<RuvProgram>().Add(program);
         await dbContext.SaveChangesAsync(CancellationToken.None);
         RefreshProgramHandler sut = CreateHandler(dbContext);
 
         // Act
-        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
+        RuvarrResult result = await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
 
         // Assert
-        _tvdbEpisodeLookupNotifier.Items.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public async Task DoesNotEnqueueEpisodeLookupWhenProgramHasSingleEpisode()
-    {
-        // Arrange
-        using RuvarrDbContext dbContext = CreateDbContext();
-        TvdbSeries series = new TvdbSeriesBuilder().Build();
-        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithMultipleEpisodes(false).Build();
-        program.MatchTvdb(series);
-        dbContext.Set<RuvProgram>().Add(program);
-        await dbContext.SaveChangesAsync(CancellationToken.None);
-        RefreshProgramHandler sut = CreateHandler(dbContext);
-
-        // Act
-        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
-
-        // Assert
-        _tvdbEpisodeLookupNotifier.Items.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public async Task EnqueuesWhenProgramHasSeriesAndMultipleEpisodes()
-    {
-        // Arrange
-        using RuvarrDbContext dbContext = CreateDbContext();
-        TvdbSeries series = new TvdbSeriesBuilder().Build();
-        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithMultipleEpisodes().Build();
-        program.TryAddEpisode("ep0001", new Uri("http://test.com"), "Þáttur 1", "", DateTime.UtcNow);
-        program.MatchTvdb(series);
-        dbContext.Set<RuvProgram>().Add(program);
-        await dbContext.SaveChangesAsync(CancellationToken.None);
-
-        int episodeLookupCountBefore = program.Episodes[0].LookupCount;
-        DateTime? episodeNextLookupBefore = program.Episodes[0].NextLookup;
-
-        RefreshProgramHandler sut = CreateHandler(dbContext);
-
-        // Act
-        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
-
-        // Assert
-        _tvdbEpisodeLookupNotifier.Items.ShouldNotBeEmpty();
-        program.Episodes[0].LookupCount.ShouldBe(episodeLookupCountBefore);
-        program.Episodes[0].NextLookup.ShouldBe(episodeNextLookupBefore);
-    }
-
-    [Fact]
-    public async Task PriorityEnqueuesProgramRefresh()
-    {
-        // Arrange
-        using RuvarrDbContext dbContext = CreateDbContext();
-        RuvProgram existingProgram = new RuvProgramBuilder().WithRuvId(10).WithName("Existing").Build();
-        RuvProgram targetProgram = new RuvProgramBuilder().WithRuvId(1).WithName("Target").Build();
-        dbContext.Set<RuvProgram>().AddRange(existingProgram, targetProgram);
-        await dbContext.SaveChangesAsync(CancellationToken.None);
-        _programRefreshNotifier.Enqueue(10, "Existing");
-        RefreshProgramHandler sut = CreateHandler(dbContext);
-
-        // Act
-        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
-
-        // Assert
-        IReadOnlyList<ProgramRefreshQueueItemSummary> items = _programRefreshNotifier.Items;
-        items.Count.ShouldBe(2);
-        items[0].RuvId.ShouldBe(1);
-    }
-
-    [Fact]
-    public async Task PriorityEnqueuesSeriesLookupWhenProgramHasNoSeries()
-    {
-        // Arrange
-        using RuvarrDbContext dbContext = CreateDbContext();
-        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithMultipleEpisodes().Build();
-        dbContext.Set<RuvProgram>().Add(program);
-        await dbContext.SaveChangesAsync(CancellationToken.None);
-        RefreshProgramHandler sut = CreateHandler(dbContext);
-
-        // Act
-        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
-
-        // Assert
-        _tvdbSeriesLookupNotifier.Items.ShouldHaveSingleItem();
-    }
-
-    [Fact]
-    public async Task DoesNotEnqueueSeriesLookupWhenProgramHasSeries()
-    {
-        // Arrange
-        using RuvarrDbContext dbContext = CreateDbContext();
-        TvdbSeries series = new TvdbSeriesBuilder().Build();
-        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithMultipleEpisodes().Build();
-        program.MatchTvdb(series);
-        dbContext.Set<RuvProgram>().Add(program);
-        await dbContext.SaveChangesAsync(CancellationToken.None);
-        RefreshProgramHandler sut = CreateHandler(dbContext);
-
-        // Act
-        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
-
-        // Assert
-        _tvdbSeriesLookupNotifier.Items.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public async Task PriorityEnqueuesEpisodeLookup()
-    {
-        // Arrange
-        using RuvarrDbContext dbContext = CreateDbContext();
-        TvdbSeries series = new TvdbSeriesBuilder().Build();
-        RuvProgram existingProgram = new RuvProgramBuilder().WithRuvId(10).WithName("Existing").WithMultipleEpisodes().Build();
-        existingProgram.MatchTvdb(new TvdbSeriesBuilder().Build());
-        RuvProgram targetProgram = new RuvProgramBuilder().WithRuvId(1).WithName("Target").WithMultipleEpisodes().Build();
-        targetProgram.TryAddEpisode("ep0001", new Uri("http://test.com"), "Episode 1", "", DateTime.UtcNow);
-        targetProgram.MatchTvdb(series);
-        dbContext.Set<RuvProgram>().AddRange(existingProgram, targetProgram);
-        await dbContext.SaveChangesAsync(CancellationToken.None);
-        _tvdbEpisodeLookupNotifier.Enqueue(10, "Existing");
-        RefreshProgramHandler sut = CreateHandler(dbContext);
-
-        // Act
-        await sut.Handle(new RefreshProgramCommand(1), CancellationToken.None);
-
-        // Assert
-        IReadOnlyList<TvdbEpisodeLookupQueueItemSummary> items = _tvdbEpisodeLookupNotifier.Items;
-        items.Count.ShouldBe(2);
-        items[0].RuvId.ShouldBe(1);
+        result.IsSuccess.ShouldBeTrue();
     }
 }

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/RequestRefresh.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/RequestRefresh.cs
@@ -1,0 +1,72 @@
+using Ruvarr.Programs.Domain;
+using Ruvarr.Programs.Events;
+using Ruvarr.Testing.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.Domain.RuvProgramTests;
+
+public sealed class RequestRefresh
+{
+    [Fact]
+    public void RaisesProgramRefreshRequestedEvent()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().WithRuvId(42).WithName("Test Program").Build();
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.RequestRefresh();
+
+        // Assert
+        ProgramRefreshRequestedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProgramRefreshRequestedEvent>();
+        @event.RuvId.ShouldBe(42);
+        @event.Name.ShouldBe("Test Program");
+    }
+
+    [Fact]
+    public void SetsHasSeriesToTrueWhenProgramHasSeries()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+        sut.MatchTvdb(new TvdbSeriesBuilder().Build());
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.RequestRefresh();
+
+        // Assert
+        ProgramRefreshRequestedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProgramRefreshRequestedEvent>();
+        @event.HasSeries.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetsHasSeriesToFalseWhenProgramHasNoSeries()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.RequestRefresh();
+
+        // Assert
+        ProgramRefreshRequestedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProgramRefreshRequestedEvent>();
+        @event.HasSeries.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SetsHasMultipleEpisodesFromProgram()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().WithMultipleEpisodes().Build();
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.RequestRefresh();
+
+        // Assert
+        ProgramRefreshRequestedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProgramRefreshRequestedEvent>();
+        @event.HasMultipleEpisodes.ShouldBeTrue();
+    }
+}

--- a/tests/Ruvarr.UnitTests/Programs/ProgramRefreshRequestedEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramRefreshRequestedEventHandlerTests/Handle.cs
@@ -1,0 +1,140 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Contracts;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
+using Ruvarr.Programs.Events;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.ProgramRefreshRequestedEventHandlerTests;
+
+public sealed class Handle
+{
+    private readonly ProgramRefreshNotifier _programRefreshNotifier = new();
+    private readonly TvdbSeriesLookupNotifier _tvdbSeriesLookupNotifier = new();
+    private readonly TvdbEpisodeLookupNotifier _tvdbEpisodeLookupNotifier = new();
+    private readonly DomainEventBroadcaster _broadcaster = new();
+
+    private ProgramRefreshRequestedEventHandler CreateSut() => new(
+        _programRefreshNotifier, _tvdbSeriesLookupNotifier, _tvdbEpisodeLookupNotifier, _broadcaster);
+
+    [Fact]
+    public async Task PriorityEnqueuesProgramRefresh()
+    {
+        // Arrange
+        ProgramRefreshRequestedEventHandler sut = CreateSut();
+        _programRefreshNotifier.Enqueue(10, "Existing");
+        ProgramRefreshRequestedEvent @event = new(1, "Target", HasSeries: false, HasMultipleEpisodes: false);
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        IReadOnlyList<ProgramRefreshQueueItemSummary> items = _programRefreshNotifier.Items;
+        items.Count.ShouldBe(2);
+        items[0].RuvId.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task PublishesProgramRefreshQueueChangedEvent()
+    {
+        // Arrange
+        ProgramRefreshRequestedEventHandler sut = CreateSut();
+        ProgramRefreshRequestedEvent @event = new(1, "Test", HasSeries: false, HasMultipleEpisodes: false);
+
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+        QueueChangedEvent<ProgramRefreshQueueItemSummary>? received = null;
+        Task watchTask = Task.Run(async () =>
+        {
+            await foreach (QueueChangedEvent<ProgramRefreshQueueItemSummary> e in _broadcaster.Subscribe<QueueChangedEvent<ProgramRefreshQueueItemSummary>>(cts.Token))
+            {
+                received = e;
+                await cts.CancelAsync();
+            }
+        }, cts.Token);
+
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Task.WhenAny(watchTask, Task.Delay(2000, TestContext.Current.CancellationToken));
+        received.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task PriorityEnqueuesSeriesLookupWhenProgramHasNoSeries()
+    {
+        // Arrange
+        ProgramRefreshRequestedEventHandler sut = CreateSut();
+        ProgramRefreshRequestedEvent @event = new(1, "Test", HasSeries: false, HasMultipleEpisodes: true);
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        _tvdbSeriesLookupNotifier.Items.ShouldHaveSingleItem();
+        _tvdbSeriesLookupNotifier.Items[0].RuvId.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task DoesNotEnqueueSeriesLookupWhenProgramHasSeries()
+    {
+        // Arrange
+        ProgramRefreshRequestedEventHandler sut = CreateSut();
+        ProgramRefreshRequestedEvent @event = new(1, "Test", HasSeries: true, HasMultipleEpisodes: true);
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        _tvdbSeriesLookupNotifier.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task PriorityEnqueuesEpisodeLookupWhenProgramHasSeriesAndMultipleEpisodes()
+    {
+        // Arrange
+        ProgramRefreshRequestedEventHandler sut = CreateSut();
+        _tvdbEpisodeLookupNotifier.Enqueue(10, "Existing");
+        ProgramRefreshRequestedEvent @event = new(1, "Target", HasSeries: true, HasMultipleEpisodes: true);
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        IReadOnlyList<TvdbEpisodeLookupQueueItemSummary> items = _tvdbEpisodeLookupNotifier.Items;
+        items.Count.ShouldBe(2);
+        items[0].RuvId.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task DoesNotEnqueueEpisodeLookupWhenProgramHasNoSeries()
+    {
+        // Arrange
+        ProgramRefreshRequestedEventHandler sut = CreateSut();
+        ProgramRefreshRequestedEvent @event = new(1, "Test", HasSeries: false, HasMultipleEpisodes: true);
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        _tvdbEpisodeLookupNotifier.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DoesNotEnqueueEpisodeLookupWhenProgramHasSingleEpisode()
+    {
+        // Arrange
+        ProgramRefreshRequestedEventHandler sut = CreateSut();
+        ProgramRefreshRequestedEvent @event = new(1, "Test", HasSeries: true, HasMultipleEpisodes: false);
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        _tvdbEpisodeLookupNotifier.Items.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- Replace imperative `PriorityEnqueue` and `Publish` calls in `RefreshProgramHandler` with a `ProgramRefreshRequestedEvent` domain event raised from `RuvProgram.RequestRefresh()`
- Move all queue enqueuing and `QueueChangedEvent` publishing logic into `ProgramRefreshRequestedEventHandler`
- Simplify `RefreshProgramHandler` to only load the program, call the domain method, and save

Closes #123

## Test plan
- [x] Unit tests for `RuvProgram.RequestRefresh()` (4 tests)
- [x] Unit tests for `ProgramRefreshRequestedEventHandler` (7 tests covering priority enqueue, conditional series/episode lookup, QueueChangedEvent publishing)
- [x] Updated `RefreshProgramHandler` tests (2 tests: not-found error, success)
- [x] `dotnet build` passes with 0 warnings
- [x] `dotnet test` passes: 434 tests (399 unit + 35 integration), 0 failures