### PR TITLE
Extract inline SVG icons into reusable Icon component

### DIFF
--- a/src/Ruvarr/Components/Icon.razor
+++ b/src/Ruvarr/Components/Icon.razor
@@ -1,0 +1,86 @@
+@namespace Ruvarr.Components
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+     stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+     class="@Class" width="@Width" height="@Height"
+     aria-label="@AriaLabel" aria-hidden="@(AriaLabel is null ? "true" : null)">
+    @switch (Type)
+    {
+        case IconType.BackArrow:
+            <path d="M19 12H5" />
+            <path d="m12 19-7-7 7-7" />
+            break;
+        case IconType.Checkmark:
+            <polyline points="20 6 9 17 4 12" />
+            break;
+        case IconType.CheckmarkCircle:
+            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+            <polyline points="22 4 12 14.01 9 11.01" />
+            break;
+        case IconType.Clock:
+            <circle cx="12" cy="12" r="10" />
+            <polyline points="12 6 12 12 16 14" />
+            break;
+        case IconType.Copy:
+            <rect width="8" height="4" x="8" y="2" rx="1" ry="1" />
+            <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+            break;
+        case IconType.Download:
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+            break;
+        case IconType.ExternalLink:
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+            <polyline points="15 3 21 3 21 9" />
+            <line x1="10" y1="14" x2="21" y2="3" />
+            break;
+        case IconType.Eye:
+            <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+            <circle cx="12" cy="12" r="3" />
+            break;
+        case IconType.EyeOff:
+            <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+            <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+            <line x1="1" y1="1" x2="23" y2="23" />
+            break;
+        case IconType.Link:
+            <path d="M9 17H7A5 5 0 0 1 7 7h2" />
+            <path d="M15 7h2a5 5 0 1 1 0 10h-2" />
+            <line x1="8" y1="12" x2="16" y2="12" />
+            break;
+        case IconType.LinkDiagonal:
+            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+            break;
+        case IconType.Refresh:
+            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+            <path d="M3 3v5h5" />
+            break;
+        case IconType.Spinner:
+            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            break;
+        case IconType.Warning:
+            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+            <line x1="12" y1="9" x2="12" y2="13" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+            break;
+    }
+</svg>
+
+@code {
+    [Parameter, EditorRequired]
+    public IconType Type { get; set; }
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    [Parameter]
+    public string? AriaLabel { get; set; }
+
+    [Parameter]
+    public string? Width { get; set; }
+
+    [Parameter]
+    public string? Height { get; set; }
+}

--- a/src/Ruvarr/Components/IconType.cs
+++ b/src/Ruvarr/Components/IconType.cs
@@ -1,0 +1,19 @@
+namespace Ruvarr.Components;
+
+public enum IconType
+{
+    BackArrow,
+    Checkmark,
+    CheckmarkCircle,
+    Clock,
+    Copy,
+    Download,
+    ExternalLink,
+    Eye,
+    EyeOff,
+    Link,
+    LinkDiagonal,
+    Refresh,
+    Spinner,
+    Warning
+}

--- a/src/Ruvarr/Downloads/Components/DownloadQueue.razor
+++ b/src/Ruvarr/Downloads/Components/DownloadQueue.razor
@@ -41,20 +41,13 @@ else
                         @switch (item.Status)
                         {
                             case DownloadQueueStatus.Pending:
-                                <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Pending">
-                                    <circle cx="12" cy="12" r="10" />
-                                    <polyline points="12 6 12 12 16 14" />
-                                </svg>
+                                <Icon Type="IconType.Clock" Class="icon" AriaLabel="Pending" />
                                 break;
                             case DownloadQueueStatus.Downloading:
-                                <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Downloading">
-                                    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                                </svg>
+                                <Icon Type="IconType.Spinner" Class="icon icon--spinning" AriaLabel="Downloading" />
                                 break;
                             case DownloadQueueStatus.Complete:
-                                <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Complete">
-                                    <polyline points="20 6 9 17 4 12" />
-                                </svg>
+                                <Icon Type="IconType.Checkmark" Class="icon" AriaLabel="Complete" />
                                 break;
                         }
                     </td>

--- a/src/Ruvarr/ProgramRefreshQueue/Components/ProgramRefreshQueue.razor
+++ b/src/Ruvarr/ProgramRefreshQueue/Components/ProgramRefreshQueue.razor
@@ -36,15 +36,10 @@ else
                         @switch (item.Status)
                         {
                             case ProgramRefreshStatus.Pending:
-                                <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Pending">
-                                    <circle cx="12" cy="12" r="10" />
-                                    <polyline points="12 6 12 12 16 14" />
-                                </svg>
+                                <Icon Type="IconType.Clock" Class="icon" AriaLabel="Pending" />
                                 break;
                             case ProgramRefreshStatus.Processing:
-                                <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Processing">
-                                    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                                </svg>
+                                <Icon Type="IconType.Spinner" Class="icon icon--spinning" AriaLabel="Processing" />
                                 break;
                         }
                     </td>

--- a/src/Ruvarr/Programs/ProgramDetail.razor
+++ b/src/Ruvarr/Programs/ProgramDetail.razor
@@ -18,9 +18,7 @@
 @inject IDomainEventBroadcaster Broadcaster
 
 <a class="detail-back" href="/">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true">
-        <path d="M19 12H5" /><path d="m12 19-7-7 7-7" />
-    </svg>
+    <Icon Type="IconType.BackArrow" Width="14" Height="14" />
     Programs
 </a>
 
@@ -58,27 +56,19 @@ else
             @if (_refreshQueue.TryGetValue(_program.ProgramRuvId, out ProgramRefreshStatus status) && status == ProgramRefreshStatus.Processing)
             {
                 <span class="icon-button">
-                    <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Refreshing">
-                        <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                    </svg>
+                    <Icon Type="IconType.Spinner" Class="icon icon--spinning" AriaLabel="Refreshing" />
                 </span>
             }
             else if (_refreshQueue.ContainsKey(_program.ProgramRuvId) || _pendingRefresh.Contains(_program.ProgramRuvId))
             {
                 <span class="icon-button">
-                    <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Pending">
-                        <circle cx="12" cy="12" r="10" />
-                        <polyline points="12 6 12 12 16 14" />
-                    </svg>
+                    <Icon Type="IconType.Clock" Class="icon" AriaLabel="Pending" />
                 </span>
             }
             else
             {
                 <button class="icon-button" @onclick="() => RefreshProgram(_program.ProgramRuvId)" title="Refresh program">
-                    <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Refresh">
-                        <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-                        <path d="M3 3v5h5" />
-                    </svg>
+                    <Icon Type="IconType.Refresh" Class="icon" AriaLabel="Refresh" />
                 </button>
             }
         </div>
@@ -145,22 +135,13 @@ else
                                 @if (_copied.Contains(titleKey))
                                 {
                                     <span class="icon-button copy-button copy-button--copied">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
-                                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                                             aria-label="Copied">
-                                            <polyline points="20 6 9 17 4 12" />
-                                        </svg>
+                                        <Icon Type="IconType.Checkmark" Class="icon" AriaLabel="Copied" />
                                     </span>
                                 }
                                 else
                                 {
                                     <button class="icon-button copy-button" @onclick="() => CopyToClipboard(episode.EpisodeTitle, titleKey)" title="Copy title">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
-                                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                                             aria-label="Copy">
-                                            <rect width="8" height="4" x="8" y="2" rx="1" ry="1" />
-                                            <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
-                                        </svg>
+                                        <Icon Type="IconType.Copy" Class="icon" AriaLabel="Copy" />
                                     </button>
                                 }
                             }
@@ -173,22 +154,13 @@ else
                                 @if (_copied.Contains(descKey))
                                 {
                                     <span class="icon-button copy-button copy-button--copied">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
-                                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                                             aria-label="Copied">
-                                            <polyline points="20 6 9 17 4 12" />
-                                        </svg>
+                                        <Icon Type="IconType.Checkmark" Class="icon" AriaLabel="Copied" />
                                     </span>
                                 }
                                 else
                                 {
                                     <button class="icon-button copy-button" @onclick="() => CopyToClipboard(episode.EpisodeDescription, descKey)" title="Copy description">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
-                                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                                             aria-label="Copy">
-                                            <rect width="8" height="4" x="8" y="2" rx="1" ry="1" />
-                                            <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
-                                        </svg>
+                                        <Icon Type="IconType.Copy" Class="icon" AriaLabel="Copy" />
                                     </button>
                                 }
                             }
@@ -198,53 +170,33 @@ else
                                 @if (episode.RuvUrl is not null)
                                 {
                                     <a class="icon-button" href="@episode.RuvUrl" target="_blank" rel="noopener noreferrer" title="View on RÚV">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
-                                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                                             aria-label="View on RÚV">
-                                            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-                                            <polyline points="15 3 21 3 21 9" />
-                                            <line x1="10" y1="14" x2="21" y2="3" />
-                                        </svg>
+                                        <Icon Type="IconType.ExternalLink" Class="icon" AriaLabel="View on RÚV" />
                                     </a>
                                 }
                                 @if (_program.SeriesName is not null)
                                 {
                                     <button class="icon-button" @onclick="() => OpenMatchDialog(episode.EpisodeRuvId, episode.TvdbId)" title="Match to TVDB">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Match to TVDB">
-                                            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-                                            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-                                        </svg>
+                                        <Icon Type="IconType.LinkDiagonal" Class="icon" AriaLabel="Match to TVDB" />
                                     </button>
                                 }
                                 @if (_downloading.Contains(episode.EpisodeRuvId))
                                 {
-                                    <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Queuing">
-                                        <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                                    </svg>
+                                    <Icon Type="IconType.Spinner" Class="icon icon--spinning" AriaLabel="Queuing" />
                                 }
                                 else if (_queued.Contains(episode.EpisodeRuvId))
                                 {
-                                    <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Queued">
-                                        <polyline points="20 6 9 17 4 12" />
-                                    </svg>
+                                    <Icon Type="IconType.Checkmark" Class="icon" AriaLabel="Queued" />
                                 }
                                 else if (_failed.Contains(episode.EpisodeRuvId))
                                 {
                                     <button class="icon-button icon-button--error" @onclick="() => Download(episode.EpisodeRuvId)" title="Retry">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Retry">
-                                            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-                                            <path d="M3 3v5h5" />
-                                        </svg>
+                                        <Icon Type="IconType.Refresh" Class="icon" AriaLabel="Retry" />
                                     </button>
                                 }
                                 else
                                 {
                                     <button class="icon-button" @onclick="() => Download(episode.EpisodeRuvId)" title="Download">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Download">
-                                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                                            <polyline points="7 10 12 15 17 10" />
-                                            <line x1="12" y1="15" x2="12" y2="3" />
-                                        </svg>
+                                        <Icon Type="IconType.Download" Class="icon" AriaLabel="Download" />
                                     </button>
                                 }
                             </div>

--- a/src/Ruvarr/Programs/Programs.razor
+++ b/src/Ruvarr/Programs/Programs.razor
@@ -96,28 +96,17 @@ else
                         <td class="col-center">
                             @if (program.IsMonitored)
                             {
-                                <svg class="icon icon--monitored" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Monitored">
-                                    <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
-                                    <circle cx="12" cy="12" r="3" />
-                                </svg>
+                                <Icon Type="IconType.Eye" Class="icon icon--monitored" AriaLabel="Monitored" />
                             }
                             else
                             {
-                                <svg class="icon icon--unmonitored" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Unmonitored">
-                                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
-                                    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
-                                    <line x1="1" y1="1" x2="23" y2="23" />
-                                </svg>
+                                <Icon Type="IconType.EyeOff" Class="icon icon--unmonitored" AriaLabel="Unmonitored" />
                             }
                         </td>
                         <td class="col-center">
                             @if (program.HasMissingEpisodes)
                             {
-                                <svg class="icon icon--missing" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Missing episodes">
-                                    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-                                    <line x1="12" y1="9" x2="12" y2="13" />
-                                    <line x1="12" y1="17" x2="12.01" y2="17" />
-                                </svg>
+                                <Icon Type="IconType.Warning" Class="icon icon--missing" AriaLabel="Missing episodes" />
                             }
                         </td>
                         <td>
@@ -143,63 +132,38 @@ else
                                     _ => ("icon--matched-none", "No episodes matched"),
                                 };
                             }
-                            <svg class="icon @cssClass" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                                 aria-label="@ariaLabel">
-                                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
-                                <polyline points="22 4 12 14.01 9 11.01" />
-                            </svg>
+                            <Icon Type="IconType.CheckmarkCircle" Class="@($"icon {cssClass}")" AriaLabel="@ariaLabel" />
                         </td>
                         <td>
                             <div class="row-actions">
                                 @if (program.TvdbSeriesId is null)
                                 {
                                     <button class="icon-button" @onclick="() => OpenMatchProgramDialog(program)" title="Match to TVDB">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
-                                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                                             aria-label="Match to TVDB">
-                                            <path d="M9 17H7A5 5 0 0 1 7 7h2" />
-                                            <path d="M15 7h2a5 5 0 1 1 0 10h-2" />
-                                            <line x1="8" y1="12" x2="16" y2="12" />
-                                        </svg>
+                                        <Icon Type="IconType.Link" Class="icon" AriaLabel="Match to TVDB" />
                                     </button>
                                 }
                                 @if (program.RuvUrl is not null)
                                 {
                                     <a class="icon-button" href="@program.RuvUrl" target="_blank" rel="noopener noreferrer" title="View on RÚV">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
-                                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                                             aria-label="View on RÚV">
-                                            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-                                            <polyline points="15 3 21 3 21 9" />
-                                            <line x1="10" y1="14" x2="21" y2="3" />
-                                        </svg>
+                                        <Icon Type="IconType.ExternalLink" Class="icon" AriaLabel="View on RÚV" />
                                     </a>
                                 }
                                 @if (_refreshQueue.TryGetValue(program.ProgramRuvId, out ProgramRefreshStatus status) && status == ProgramRefreshStatus.Processing)
                                 {
                                     <span class="icon-button">
-                                        <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Refreshing">
-                                            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                                        </svg>
+                                        <Icon Type="IconType.Spinner" Class="icon icon--spinning" AriaLabel="Refreshing" />
                                     </span>
                                 }
                                 else if (_refreshQueue.ContainsKey(program.ProgramRuvId) || _pendingRefresh.Contains(program.ProgramRuvId))
                                 {
                                     <span class="icon-button">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Pending">
-                                            <circle cx="12" cy="12" r="10" />
-                                            <polyline points="12 6 12 12 16 14" />
-                                        </svg>
+                                        <Icon Type="IconType.Clock" Class="icon" AriaLabel="Pending" />
                                     </span>
                                 }
                                 else
                                 {
                                     <button class="icon-button" @onclick="() => RefreshProgram(program.ProgramRuvId)" title="Refresh">
-                                        <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Refresh">
-                                            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-                                            <path d="M3 3v5h5" />
-                                        </svg>
+                                        <Icon Type="IconType.Refresh" Class="icon" AriaLabel="Refresh" />
                                     </button>
                                 }
                             </div>

--- a/src/Ruvarr/TvdbEpisodeLookup/Components/TvdbEpisodeLookupQueue.razor
+++ b/src/Ruvarr/TvdbEpisodeLookup/Components/TvdbEpisodeLookupQueue.razor
@@ -36,15 +36,10 @@ else
                         @switch (item.Status)
                         {
                             case TvdbEpisodeLookupStatus.Pending:
-                                <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Pending">
-                                    <circle cx="12" cy="12" r="10" />
-                                    <polyline points="12 6 12 12 16 14" />
-                                </svg>
+                                <Icon Type="IconType.Clock" Class="icon" AriaLabel="Pending" />
                                 break;
                             case TvdbEpisodeLookupStatus.Processing:
-                                <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Processing">
-                                    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                                </svg>
+                                <Icon Type="IconType.Spinner" Class="icon icon--spinning" AriaLabel="Processing" />
                                 break;
                         }
                     </td>

--- a/src/Ruvarr/TvdbSeriesLookup/Components/TvdbSeriesLookupQueue.razor
+++ b/src/Ruvarr/TvdbSeriesLookup/Components/TvdbSeriesLookupQueue.razor
@@ -36,15 +36,10 @@ else
                         @switch (item.Status)
                         {
                             case TvdbSeriesLookupStatus.Pending:
-                                <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Pending">
-                                    <circle cx="12" cy="12" r="10" />
-                                    <polyline points="12 6 12 12 16 14" />
-                                </svg>
+                                <Icon Type="IconType.Clock" Class="icon" AriaLabel="Pending" />
                                 break;
                             case TvdbSeriesLookupStatus.Processing:
-                                <svg class="icon icon--spinning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Processing">
-                                    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                                </svg>
+                                <Icon Type="IconType.Spinner" Class="icon icon--spinning" AriaLabel="Processing" />
                                 break;
                         }
                     </td>

--- a/src/Ruvarr/_Imports.razor
+++ b/src/Ruvarr/_Imports.razor
@@ -2,4 +2,5 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop
+@using Ruvarr.Components
 @using static Microsoft.AspNetCore.Components.Web.RenderMode

--- a/tests/Ruvarr.UnitTests/Components/IconTests.cs
+++ b/tests/Ruvarr.UnitTests/Components/IconTests.cs
@@ -1,0 +1,150 @@
+using AngleSharp.Dom;
+
+using Bunit;
+
+using Ruvarr.Components;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Components;
+
+public sealed class IconTests : BunitContext
+{
+    [Theory]
+    [InlineData(IconType.BackArrow)]
+    [InlineData(IconType.Checkmark)]
+    [InlineData(IconType.CheckmarkCircle)]
+    [InlineData(IconType.Clock)]
+    [InlineData(IconType.Copy)]
+    [InlineData(IconType.Download)]
+    [InlineData(IconType.ExternalLink)]
+    [InlineData(IconType.Eye)]
+    [InlineData(IconType.EyeOff)]
+    [InlineData(IconType.Link)]
+    [InlineData(IconType.LinkDiagonal)]
+    [InlineData(IconType.Refresh)]
+    [InlineData(IconType.Spinner)]
+    [InlineData(IconType.Warning)]
+    public void Renders_Svg_For_Each_IconType(IconType type)
+    {
+        IRenderedComponent<Icon> cut = Render<Icon>(parameters => parameters
+            .Add(p => p.Type, type));
+
+        IElement svg = cut.Find("svg");
+        svg.ShouldNotBeNull();
+        svg.GetAttribute("xmlns").ShouldBe("http://www.w3.org/2000/svg");
+        svg.GetAttribute("viewBox").ShouldBe("0 0 24 24");
+        svg.GetAttribute("fill").ShouldBe("none");
+        svg.GetAttribute("stroke").ShouldBe("currentColor");
+        svg.GetAttribute("stroke-width").ShouldBe("2");
+        svg.GetAttribute("stroke-linecap").ShouldBe("round");
+        svg.GetAttribute("stroke-linejoin").ShouldBe("round");
+        svg.InnerHtml.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void Renders_Class_Attribute_When_Specified()
+    {
+        IRenderedComponent<Icon> cut = Render<Icon>(parameters => parameters
+            .Add(p => p.Type, IconType.Checkmark)
+            .Add(p => p.Class, "icon icon--matched-all"));
+
+        IElement svg = cut.Find("svg");
+        svg.GetAttribute("class").ShouldBe("icon icon--matched-all");
+    }
+
+    [Fact]
+    public void Does_Not_Render_Class_Attribute_When_Null()
+    {
+        IRenderedComponent<Icon> cut = Render<Icon>(parameters => parameters
+            .Add(p => p.Type, IconType.Checkmark));
+
+        IElement svg = cut.Find("svg");
+        svg.GetAttribute("class").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Renders_AriaLabel_When_Specified()
+    {
+        IRenderedComponent<Icon> cut = Render<Icon>(parameters => parameters
+            .Add(p => p.Type, IconType.Download)
+            .Add(p => p.AriaLabel, "Download episode"));
+
+        IElement svg = cut.Find("svg");
+        svg.GetAttribute("aria-label").ShouldBe("Download episode");
+        svg.GetAttribute("aria-hidden").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Renders_AriaHidden_When_AriaLabel_Is_Null()
+    {
+        IRenderedComponent<Icon> cut = Render<Icon>(parameters => parameters
+            .Add(p => p.Type, IconType.BackArrow));
+
+        IElement svg = cut.Find("svg");
+        svg.GetAttribute("aria-hidden").ShouldBe("true");
+        svg.GetAttribute("aria-label").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Renders_Custom_Width_And_Height()
+    {
+        IRenderedComponent<Icon> cut = Render<Icon>(parameters => parameters
+            .Add(p => p.Type, IconType.BackArrow)
+            .Add(p => p.Width, "14")
+            .Add(p => p.Height, "14"));
+
+        IElement svg = cut.Find("svg");
+        svg.GetAttribute("width").ShouldBe("14");
+        svg.GetAttribute("height").ShouldBe("14");
+    }
+
+    [Fact]
+    public void Does_Not_Render_Width_And_Height_When_Null()
+    {
+        IRenderedComponent<Icon> cut = Render<Icon>(parameters => parameters
+            .Add(p => p.Type, IconType.Checkmark));
+
+        IElement svg = cut.Find("svg");
+        svg.GetAttribute("width").ShouldBeNull();
+        svg.GetAttribute("height").ShouldBeNull();
+    }
+
+    [Fact]
+    public void BackArrow_Renders_Correct_Paths()
+    {
+        IRenderedComponent<Icon> cut = Render<Icon>(parameters => parameters
+            .Add(p => p.Type, IconType.BackArrow));
+
+        cut.Find("svg").InnerHtml.ShouldContain("M19 12H5");
+        cut.Find("svg").InnerHtml.ShouldContain("m12 19-7-7 7-7");
+    }
+
+    [Fact]
+    public void Checkmark_Renders_Correct_Polyline()
+    {
+        IRenderedComponent<Icon> cut = Render<Icon>(parameters => parameters
+            .Add(p => p.Type, IconType.Checkmark));
+
+        cut.Find("svg polyline").GetAttribute("points").ShouldBe("20 6 9 17 4 12");
+    }
+
+    [Fact]
+    public void Clock_Renders_Circle_And_Polyline()
+    {
+        IRenderedComponent<Icon> cut = Render<Icon>(parameters => parameters
+            .Add(p => p.Type, IconType.Clock));
+
+        cut.Find("svg circle").GetAttribute("cx").ShouldBe("12");
+        cut.Find("svg polyline").GetAttribute("points").ShouldBe("12 6 12 12 16 14");
+    }
+
+    [Fact]
+    public void Spinner_Renders_Correct_Path()
+    {
+        IRenderedComponent<Icon> cut = Render<Icon>(parameters => parameters
+            .Add(p => p.Type, IconType.Spinner));
+
+        cut.Find("svg").InnerHtml.ShouldContain("M21 12a9 9 0 1 1-6.219-8.56");
+    }
+}


### PR DESCRIPTION
## Summary
- Extract 32 inline SVGs across 6 Razor files into a single `Icon.razor` component with an `IconType` enum (14 members)
- Eliminates ~200 lines of duplicated SVG markup and centralises icon management
- All existing CSS rules (`.icon`, `.icon--spinning`, `.icon--monitored`, etc.) continue to work unchanged

## Test plan
- [ ] All 460 existing tests pass (`dotnet test`)
- [ ] Verify no `<svg` elements remain in the 6 affected Razor files
- [ ] Visual check: icons render identically in size, colour, position, and animation
- [ ] Back-arrow icon retains 14x14px size on program detail page
- [ ] Copy-button icons retain 0.85rem size

Closes #148