### PR TITLE
Replace free-text TVDB input with season/episode selectors (#97)

### DIFF
--- a/src/Ruvarr/Contracts/TvdbSeriesEpisode.cs
+++ b/src/Ruvarr/Contracts/TvdbSeriesEpisode.cs
@@ -1,0 +1,3 @@
+namespace Ruvarr.Contracts;
+
+public sealed record TvdbSeriesEpisode(int TvdbId, string Name, int SeasonNumber, int EpisodeNumber);

--- a/src/Ruvarr/Programs/MatchEpisodeDialog.razor
+++ b/src/Ruvarr/Programs/MatchEpisodeDialog.razor
@@ -1,24 +1,83 @@
 @namespace Ruvarr.Programs
 @using Ruvarr.Abstractions
+@using Ruvarr.Contracts
 @using Ruvarr.Programs.Commands.MatchEpisode
+@using Ruvarr.Programs.Queries.GetTvdbSeriesEpisodes
 @implements IAsyncDisposable
 @inject IServiceScopeFactory ScopeFactory
 @inject IJSRuntime Js
 
 <dialog @ref="_dialog" @onclose="OnDialogClose">
     <h2>Match to TVDB</h2>
-    <label>
-        TVDB Episode ID
-        <input type="number" min="1" @bind="_tvdbIdInput" @bind:event="oninput" @onkeydown="HandleKeyDown" />
-    </label>
+    @if (_isLoading)
+    {
+        <div class="dialog-spinner-container" role="status" aria-label="Loading episodes">
+            <span class="dialog-spinner"></span>
+        </div>
+    }
+    else if (_errorMessage is not null)
+    {
+        <p class="dialog-error">@_errorMessage</p>
+    }
+    else if (_seasons.Count == 0)
+    {
+        <p class="dialog-error">No episodes found for this series.</p>
+    }
+    else
+    {
+        <label>
+            Season
+            <select class="dialog-select" value="@_selectedSeason" @onchange="OnSeasonChanged">
+                @if (_selectedSeason is null)
+                {
+                    <option value="">Select a season</option>
+                }
+                @foreach (int season in _seasons)
+                {
+                    <option value="@season">Season @season</option>
+                }
+            </select>
+        </label>
+        <label>
+            Episode
+            <select class="dialog-select"
+                    disabled="@(_selectedSeason is null || _seasonEpisodes.Count == 0)"
+                    @bind="_selectedEpisodeId"
+                    @bind:event="onchange"
+                    @onkeydown="HandleKeyDown">
+                @if (_selectedSeason is null)
+                {
+                    <option value="">Select a season first</option>
+                }
+                else if (_seasonEpisodes.Count == 0)
+                {
+                    <option value="">No episodes found</option>
+                }
+                else
+                {
+                    @if (_selectedEpisodeId is null)
+                    {
+                        <option value="">Select an episode</option>
+                    }
+                    @foreach (TvdbSeriesEpisode episode in _seasonEpisodes)
+                    {
+                        <option value="@episode.TvdbId">E@(episode.EpisodeNumber.ToString("D2")) - @episode.Name</option>
+                    }
+                }
+            </select>
+        </label>
+    }
     <div class="dialog-actions">
-        <button class="dialog-button dialog-button--primary" @onclick="SubmitMatch" disabled="@IsMatchDisabled(_tvdbIdInput, _currentTvdbId, _isSubmitting)">
-            @if (_isSubmitting)
-            {
-                <span class="button-spinner"></span>
-            }
-            Match
-        </button>
+        @if (!_isLoading)
+        {
+            <button class="dialog-button dialog-button--primary" @onclick="SubmitMatch" disabled="@IsMatchDisabled(_selectedEpisodeId, _currentTvdbId, _isSubmitting)">
+                @if (_isSubmitting)
+                {
+                    <span class="button-spinner"></span>
+                }
+                Match
+            </button>
+        }
         <button class="dialog-button" @onclick="CloseAsync" disabled="@_isSubmitting">Cancel</button>
     </div>
 </dialog>
@@ -29,17 +88,135 @@
 
     private ElementReference _dialog;
     private string? _ruvId;
-    private string _tvdbIdInput = string.Empty;
     private int? _currentTvdbId;
+    private bool _isLoading;
     private bool _isSubmitting;
+    private string? _errorMessage;
     private readonly CancellationTokenSource _cts = new();
 
-    public async Task OpenAsync(string ruvId, int? currentTvdbId)
+    private IReadOnlyList<TvdbSeriesEpisode> _allEpisodes = [];
+    private List<int> _seasons = [];
+    private List<TvdbSeriesEpisode> _seasonEpisodes = [];
+    private int? _selectedSeason;
+    private int? _selectedEpisodeId;
+    private int _tvdbSeriesId;
+    private string _episodeTitle = string.Empty;
+    private List<EpisodeSummary> _siblingEpisodes = [];
+
+    public async Task OpenAsync(string ruvId, int? currentTvdbId, int tvdbSeriesId, string episodeTitle, List<EpisodeSummary> siblingEpisodes)
     {
         _ruvId = ruvId;
         _currentTvdbId = currentTvdbId;
-        _tvdbIdInput = currentTvdbId?.ToString() ?? string.Empty;
+        _tvdbSeriesId = tvdbSeriesId;
+        _episodeTitle = episodeTitle;
+        _siblingEpisodes = siblingEpisodes;
+        _isLoading = true;
+        _errorMessage = null;
+        _allEpisodes = [];
+        _seasons = [];
+        _seasonEpisodes = [];
+        _selectedSeason = null;
+        _selectedEpisodeId = null;
+
+        await InvokeAsync(StateHasChanged);
         await Js.InvokeVoidAsync("showDialog", _dialog);
+
+        await LoadEpisodesAsync();
+    }
+
+    private async Task LoadEpisodesAsync()
+    {
+        try
+        {
+            await using AsyncServiceScope scope = ScopeFactory.CreateAsyncScope();
+            IRequestHandler<GetTvdbSeriesEpisodesQuery, IReadOnlyList<TvdbSeriesEpisode>> handler =
+                scope.ServiceProvider.GetRequiredService<IRequestHandler<GetTvdbSeriesEpisodesQuery, IReadOnlyList<TvdbSeriesEpisode>>>();
+            _allEpisodes = await handler.Handle(new GetTvdbSeriesEpisodesQuery(_tvdbSeriesId), _cts.Token);
+            _seasons = [.. _allEpisodes.Select(e => e.SeasonNumber).Distinct().OrderBy(s => s)];
+
+            int? autoSeason = ResolveAutoSelectedSeason(_siblingEpisodes, _seasons);
+            if (autoSeason is not null)
+            {
+                _selectedSeason = autoSeason;
+                _seasonEpisodes = [.. _allEpisodes.Where(e => e.SeasonNumber == _selectedSeason)];
+                TryAutoSelectEpisode();
+            }
+        }
+        catch (Exception)
+        {
+            _errorMessage = "Failed to load episodes. Please try again.";
+        }
+        finally
+        {
+            _isLoading = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private void OnSeasonChanged(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out int season))
+        {
+            _selectedSeason = season;
+            _seasonEpisodes = [.. _allEpisodes.Where(ep => ep.SeasonNumber == season)];
+        }
+        else
+        {
+            _selectedSeason = null;
+            _seasonEpisodes = [];
+        }
+        _selectedEpisodeId = null;
+        TryAutoSelectEpisode();
+    }
+
+    private void TryAutoSelectEpisode()
+    {
+        if (_seasonEpisodes.Count == 0)
+        {
+            return;
+        }
+
+        if (TryGetEpisodeNumber(_episodeTitle, out int episodeNumber))
+        {
+            TvdbSeriesEpisode? match = _seasonEpisodes.FirstOrDefault(e => e.EpisodeNumber == episodeNumber);
+            if (match is not null)
+            {
+                _selectedEpisodeId = match.TvdbId;
+            }
+        }
+    }
+
+    internal static bool TryGetEpisodeNumber(string title, out int number)
+    {
+        string[] parts = title.Split(' ');
+
+        if (parts.Length < 2 || !parts[0].Equals("þáttur", StringComparison.OrdinalIgnoreCase))
+        {
+            number = 0;
+            return false;
+        }
+
+        return int.TryParse(parts[1], out number);
+    }
+
+    internal static int? ResolveAutoSelectedSeason(List<EpisodeSummary> siblingEpisodes, List<int> availableSeasons)
+    {
+        List<int> matchedSeasons = [.. siblingEpisodes
+            .Where(e => e.SeasonNumber is not null && e.SeasonNumber > 0)
+            .Select(e => e.SeasonNumber!.Value)
+            .Distinct()
+            .OrderBy(s => s)];
+
+        if (matchedSeasons.Count > 0)
+        {
+            int lowest = matchedSeasons[0];
+            if (availableSeasons.Contains(lowest))
+            {
+                return lowest;
+            }
+        }
+
+        return availableSeasons.Count > 0 ? availableSeasons[0] : null;
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
@@ -52,7 +229,14 @@
     {
         _ruvId = null;
         _currentTvdbId = null;
-        _tvdbIdInput = string.Empty;
+        _allEpisodes = [];
+        _seasons = [];
+        _seasonEpisodes = [];
+        _selectedSeason = null;
+        _selectedEpisodeId = null;
+        _errorMessage = null;
+        _episodeTitle = string.Empty;
+        _siblingEpisodes = [];
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
@@ -65,7 +249,7 @@
 
         _isSubmitting = true;
 
-        if (_ruvId is null || !int.TryParse(_tvdbIdInput, out int tvdbId) || tvdbId <= 0)
+        if (_ruvId is null || _selectedEpisodeId is null)
         {
             _isSubmitting = false;
             return;
@@ -76,7 +260,7 @@
             await using AsyncServiceScope scope = ScopeFactory.CreateAsyncScope();
             IRequestHandler<MatchEpisodeCommand> handler =
                 scope.ServiceProvider.GetRequiredService<IRequestHandler<MatchEpisodeCommand>>();
-            await handler.Handle(new MatchEpisodeCommand(_ruvId, tvdbId), _cts.Token);
+            await handler.Handle(new MatchEpisodeCommand(_ruvId, _selectedEpisodeId.Value), _cts.Token);
         }
         finally
         {
@@ -89,7 +273,7 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onkeydown")]
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
-        if (e.Key == "Enter" && !IsMatchDisabled(_tvdbIdInput, _currentTvdbId, _isSubmitting))
+        if (e.Key == "Enter" && !IsMatchDisabled(_selectedEpisodeId, _currentTvdbId, _isSubmitting))
         {
             await SubmitMatch();
         }
@@ -101,18 +285,18 @@
         _cts.Dispose();
     }
 
-    internal static bool IsMatchDisabled(string input, int? currentTvdbId, bool isSubmitting)
+    internal static bool IsMatchDisabled(int? selectedEpisodeId, int? currentTvdbId, bool isSubmitting)
     {
         if (isSubmitting)
         {
             return true;
         }
 
-        if (!int.TryParse(input, out int parsed) || parsed <= 0)
+        if (selectedEpisodeId is null)
         {
             return true;
         }
 
-        return parsed == currentTvdbId;
+        return selectedEpisodeId == currentTvdbId;
     }
 }

--- a/src/Ruvarr/Programs/ProgramDetail.razor
+++ b/src/Ruvarr/Programs/ProgramDetail.razor
@@ -175,7 +175,7 @@ else
                                 }
                                 @if (_program.SeriesName is not null)
                                 {
-                                    <button class="icon-button" @onclick="() => OpenMatchDialog(episode.EpisodeRuvId, episode.TvdbId)" title="Match to TVDB">
+                                    <button class="icon-button" @onclick="() => OpenMatchDialog(episode.EpisodeRuvId, episode.TvdbId, episode.EpisodeTitle)" title="Match to TVDB">
                                         <Icon Type="IconType.LinkDiagonal" Class="icon" AriaLabel="Match to TVDB" />
                                     </button>
                                 }
@@ -357,9 +357,9 @@ else
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
-    private async Task OpenMatchDialog(string ruvId, int? currentTvdbId)
+    private async Task OpenMatchDialog(string ruvId, int? currentTvdbId, string episodeTitle)
     {
-        await _matchDialog!.OpenAsync(ruvId, currentTvdbId);
+        await _matchDialog!.OpenAsync(ruvId, currentTvdbId, _program!.TvdbSeriesId!.Value, episodeTitle, _episodes!);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]

--- a/src/Ruvarr/Programs/Queries/GetTvdbSeriesEpisodes/GetTvdbSeriesEpisodesHandler.cs
+++ b/src/Ruvarr/Programs/Queries/GetTvdbSeriesEpisodes/GetTvdbSeriesEpisodesHandler.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Caching.Memory;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Contracts;
+using Ruvarr.Infrastructure.Tvdb;
+using Ruvarr.Infrastructure.Tvdb.Models;
+
+namespace Ruvarr.Programs.Queries.GetTvdbSeriesEpisodes;
+
+internal sealed class GetTvdbSeriesEpisodesHandler(ITvdbClient tvdbClient, IMemoryCache cache)
+    : IRequestHandler<GetTvdbSeriesEpisodesQuery, IReadOnlyList<TvdbSeriesEpisode>>
+{
+    public async Task<IReadOnlyList<TvdbSeriesEpisode>> Handle(GetTvdbSeriesEpisodesQuery request, CancellationToken cancellationToken)
+    {
+        string cacheKey = $"tvdb-series-episodes-{request.TvdbSeriesId}";
+
+        if (cache.TryGetValue(cacheKey, out IReadOnlyList<TvdbSeriesEpisode>? cached))
+        {
+            return cached!;
+        }
+
+        SeriesData? seriesData = await tvdbClient.GetSeriesAsync(request.TvdbSeriesId, cancellationToken);
+
+        if (seriesData is null)
+        {
+            return [];
+        }
+
+        List<TvdbSeriesEpisode> episodes = [.. seriesData.Episodes
+            .Where(e => e.SeasonNumber > 0)
+            .Select(e => new TvdbSeriesEpisode(e.Id, e.Name, e.SeasonNumber, e.Number))
+            .OrderBy(e => e.SeasonNumber)
+            .ThenBy(e => e.EpisodeNumber)];
+
+        cache.Set(cacheKey, episodes, TimeSpan.FromMinutes(30));
+
+        return episodes;
+    }
+}

--- a/src/Ruvarr/Programs/Queries/GetTvdbSeriesEpisodes/GetTvdbSeriesEpisodesQuery.cs
+++ b/src/Ruvarr/Programs/Queries/GetTvdbSeriesEpisodes/GetTvdbSeriesEpisodesQuery.cs
@@ -1,0 +1,3 @@
+namespace Ruvarr.Programs.Queries.GetTvdbSeriesEpisodes;
+
+public sealed record GetTvdbSeriesEpisodesQuery(int TvdbSeriesId);

--- a/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
+++ b/src/Ruvarr/Programs/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Ruvarr.Programs.Events;
 using Ruvarr.Programs.Queries.GetProgram;
 using Ruvarr.Programs.Queries.GetProgramEpisodes;
 using Ruvarr.Programs.Queries.GetPrograms;
+using Ruvarr.Programs.Queries.GetTvdbSeriesEpisodes;
 
 namespace Ruvarr.Programs;
 
@@ -25,6 +26,7 @@ internal static class ServiceCollectionExtensions
         services.AddTransient<IRequestHandler<GetProgramQuery, ProgramSummary?>, GetProgramHandler>();
         services.AddTransient<IStreamingRequestHandler<GetProgramsQuery, ProgramSummary>, GetProgramsHandler>();
         services.AddTransient<IRequestHandler<GetProgramEpisodesQuery, List<EpisodeSummary>>, GetProgramEpisodesHandler>();
+        services.AddTransient<IRequestHandler<GetTvdbSeriesEpisodesQuery, IReadOnlyList<TvdbSeriesEpisode>>, GetTvdbSeriesEpisodesHandler>();
         services.AddTransient<IRequestHandler<MatchEpisodeCommand>, MatchEpisodeHandler>();
         services.AddTransient<IRequestHandler<MatchProgramCommand>, MatchProgramHandler>();
         services.AddTransient<IRequestHandler<DownloadEpisodeCommand>, DownloadEpisodeHandler>();

--- a/src/Ruvarr/wwwroot/app.css
+++ b/src/Ruvarr/wwwroot/app.css
@@ -731,3 +731,56 @@ dialog input[type="number"]:focus {
 .badge--ruv:hover {
     opacity: 0.8;
 }
+
+.dialog-select {
+    background-color: #1a1a1a;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    color: #fff;
+    padding: 0.5rem 2rem 0.5rem 0.6rem;
+    font-size: 0.95rem;
+    width: 100%;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='rgba(255,255,255,0.4)' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.6rem center;
+}
+
+.dialog-select:focus {
+    outline: 2px solid rgba(255, 255, 255, 0.6);
+    outline-offset: 1px;
+    border-color: rgba(255, 255, 255, 0.5);
+}
+
+.dialog-select:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.dialog-select option {
+    background-color: #1a1a1a;
+}
+
+.dialog-error {
+    color: #fd4646;
+    font-size: 0.85rem;
+    margin: 0.5rem 0 0;
+}
+
+.dialog-spinner-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem 0;
+}
+
+.dialog-spinner {
+    display: inline-block;
+    width: 1.5rem;
+    height: 1.5rem;
+    border: 2px solid rgba(255, 255, 255, 0.15);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/TryGetEpisodeNumber.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/TryGetEpisodeNumber.cs
@@ -63,6 +63,22 @@ public sealed class TryGetEpisodeNumber
         number.ShouldBe(0);
     }
 
+    [Theory]
+    [InlineData("Þáttur 3 of 8", 3)]
+    [InlineData("Þáttur 1 of 10", 1)]
+    public void ReturnsTrueAndNumberForTitleWithOfSuffix(string title, int expectedNumber)
+    {
+        // Arrange
+        RuvEpisode sut = new RuvEpisodeBuilder().WithTitle(title).Build();
+
+        // Act
+        bool result = sut.TryGetEpisodeNumber(out int number);
+
+        // Assert
+        result.ShouldBeTrue();
+        number.ShouldBe(expectedNumber);
+    }
+
     [Fact]
     public void ReturnsFalseForEmptyTitle()
     {

--- a/tests/Ruvarr.UnitTests/Programs/MatchEpisodeDialogTests/HandleKeyDown.cs
+++ b/tests/Ruvarr.UnitTests/Programs/MatchEpisodeDialogTests/HandleKeyDown.cs
@@ -1,28 +1,37 @@
 using Bunit;
 
-using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 
 using NSubstitute;
 
 using Ruvarr.Abstractions;
+using Ruvarr.Contracts;
 using Ruvarr.Programs;
 using Ruvarr.Programs.Commands.MatchEpisode;
+using Ruvarr.Programs.Queries.GetTvdbSeriesEpisodes;
 
 namespace Ruvarr.UnitTests.Programs.MatchEpisodeDialogTests;
 
 public sealed class HandleKeyDown : BunitContext
 {
-    private readonly IRequestHandler<MatchEpisodeCommand> _handler;
+    private readonly IRequestHandler<MatchEpisodeCommand> _matchHandler;
+    private readonly IRequestHandler<GetTvdbSeriesEpisodesQuery, IReadOnlyList<TvdbSeriesEpisode>> _episodesHandler;
 
     public HandleKeyDown()
     {
-        _handler = Substitute.For<IRequestHandler<MatchEpisodeCommand>>();
-        _handler
+        _matchHandler = Substitute.For<IRequestHandler<MatchEpisodeCommand>>();
+        _matchHandler
             .Handle(Arg.Any<MatchEpisodeCommand>(), Arg.Any<CancellationToken>())
             .Returns(RuvarrResult.Success);
-        Services.AddTransient(_ => _handler);
+
+        _episodesHandler = Substitute.For<IRequestHandler<GetTvdbSeriesEpisodesQuery, IReadOnlyList<TvdbSeriesEpisode>>>();
+        _episodesHandler
+            .Handle(Arg.Any<GetTvdbSeriesEpisodesQuery>(), Arg.Any<CancellationToken>())
+            .Returns([new TvdbSeriesEpisode(99999, "Test Episode", 1, 1)]);
+
+        Services.AddTransient(_ => _matchHandler);
+        Services.AddTransient(_ => _episodesHandler);
         Services.AddSingleton(Substitute.For<IJSRuntime>());
     }
 
@@ -31,64 +40,51 @@ public sealed class HandleKeyDown : BunitContext
     {
         // Arrange
         IRenderedComponent<MatchEpisodeDialog> cut = Render<MatchEpisodeDialog>();
-        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: null);
-        await cut.Find("input").InputAsync(new ChangeEventArgs { Value = "99999" });
+        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: null, tvdbSeriesId: 42, episodeTitle: "þáttur 1", siblingEpisodes: []);
+        await cut.WaitForStateAsync(() => cut.FindAll("select").Count == 2);
 
+        // Season auto-selected, episode auto-selected via title parsing
         // Act
-        await cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        await cut.FindAll("select")[1].KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
 
         // Assert
-        await _handler.Received(1).Handle(Arg.Any<MatchEpisodeCommand>(), Arg.Any<CancellationToken>());
+        await _matchHandler.Received(1).Handle(Arg.Any<MatchEpisodeCommand>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task EnterKey_WhenInputIsEmpty_DoesNotInvokeSubmitMatch()
+    public async Task EnterKey_WhenNoEpisodeSelected_DoesNotInvokeSubmitMatch()
     {
         // Arrange
-        IRenderedComponent<MatchEpisodeDialog> cut = Render<MatchEpisodeDialog>();
-        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: null);
+        _episodesHandler
+            .Handle(Arg.Any<GetTvdbSeriesEpisodesQuery>(), Arg.Any<CancellationToken>())
+            .Returns([new TvdbSeriesEpisode(99999, "Test Episode", 1, 1)]);
 
+        IRenderedComponent<MatchEpisodeDialog> cut = Render<MatchEpisodeDialog>();
+        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: null, tvdbSeriesId: 42, episodeTitle: "Mynd", siblingEpisodes: []);
+        await cut.WaitForStateAsync(() => cut.FindAll("select").Count == 2);
+
+        // Episode not auto-selected because title doesn't match "þáttur N" pattern
         // Act
-        await cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        await cut.FindAll("select")[1].KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
 
         // Assert
-        await _handler.DidNotReceive().Handle(Arg.Any<MatchEpisodeCommand>(), Arg.Any<CancellationToken>());
+        await _matchHandler.DidNotReceive().Handle(Arg.Any<MatchEpisodeCommand>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task EnterKey_WhenInputUnchangedFromCurrentMatch_DoesNotInvokeSubmitMatch()
+    public async Task EnterKey_WhenSelectedMatchesCurrentTvdbId_DoesNotInvokeSubmitMatch()
     {
         // Arrange
         IRenderedComponent<MatchEpisodeDialog> cut = Render<MatchEpisodeDialog>();
-        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: 12345);
+        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: 99999, tvdbSeriesId: 42, episodeTitle: "þáttur 1", siblingEpisodes: []);
+        await cut.WaitForStateAsync(() => cut.FindAll("select").Count == 2);
 
+        // Episode auto-selected to 99999 which equals currentTvdbId
         // Act
-        await cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        await cut.FindAll("select")[1].KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
 
         // Assert
-        await _handler.DidNotReceive().Handle(Arg.Any<MatchEpisodeCommand>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task TwoRapidEnterKeys_OnlyInvokeSubmitMatchOnce()
-    {
-        // Arrange
-        TaskCompletionSource<RuvarrResult> tcs = new();
-        _handler
-            .Handle(Arg.Any<MatchEpisodeCommand>(), Arg.Any<CancellationToken>())
-            .Returns(tcs.Task);
-        IRenderedComponent<MatchEpisodeDialog> cut = Render<MatchEpisodeDialog>();
-        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: null);
-        await cut.Find("input").InputAsync(new ChangeEventArgs { Value = "99999" });
-
-        // Act — fire two Enter presses before the first handler call completes
-        Task first = cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
-        Task second = cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
-        tcs.SetResult(RuvarrResult.Success);
-        await Task.WhenAll(first, second);
-
-        // Assert
-        await _handler.Received(1).Handle(Arg.Any<MatchEpisodeCommand>(), Arg.Any<CancellationToken>());
+        await _matchHandler.DidNotReceive().Handle(Arg.Any<MatchEpisodeCommand>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -96,13 +92,13 @@ public sealed class HandleKeyDown : BunitContext
     {
         // Arrange
         IRenderedComponent<MatchEpisodeDialog> cut = Render<MatchEpisodeDialog>();
-        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: null);
-        await cut.Find("input").InputAsync(new ChangeEventArgs { Value = "99999" });
+        await cut.Instance.OpenAsync("ruv-1", currentTvdbId: null, tvdbSeriesId: 42, episodeTitle: "þáttur 1", siblingEpisodes: []);
+        await cut.WaitForStateAsync(() => cut.FindAll("select").Count == 2);
 
         // Act
-        await cut.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "a" });
+        await cut.FindAll("select")[1].KeyDownAsync(new KeyboardEventArgs { Key = "a" });
 
         // Assert
-        await _handler.DidNotReceive().Handle(Arg.Any<MatchEpisodeCommand>(), Arg.Any<CancellationToken>());
+        await _matchHandler.DidNotReceive().Handle(Arg.Any<MatchEpisodeCommand>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Ruvarr.UnitTests/Programs/MatchEpisodeDialogTests/IsMatchDisabled.cs
+++ b/tests/Ruvarr.UnitTests/Programs/MatchEpisodeDialogTests/IsMatchDisabled.cs
@@ -7,81 +7,50 @@ namespace Ruvarr.UnitTests.Programs.MatchEpisodeDialogTests;
 public sealed class IsMatchDisabled
 {
     [Fact]
-    public void ReturnsTrueWhenInputIsEmpty()
+    public void ReturnsTrueWhenSelectedEpisodeIdIsNull()
     {
-        // Arrange
-        string input = string.Empty;
-
         // Act
-        bool result = MatchEpisodeDialog.IsMatchDisabled(input, currentTvdbId: null, isSubmitting: false);
-
-        // Assert
-        result.ShouldBeTrue();
-    }
-
-    [Theory]
-    [InlineData("0")]
-    [InlineData("-1")]
-    [InlineData("-100")]
-    public void ReturnsTrueWhenParsedValueIsNotPositive(string input)
-    {
-        // Arrange
-        // (input provided via theory)
-
-        // Act
-        bool result = MatchEpisodeDialog.IsMatchDisabled(input, currentTvdbId: null, isSubmitting: false);
+        bool result = MatchEpisodeDialog.IsMatchDisabled(selectedEpisodeId: null, currentTvdbId: null, isSubmitting: false);
 
         // Assert
         result.ShouldBeTrue();
     }
 
     [Fact]
-    public void ReturnsFalseWhenValidPositiveIntegerAndCurrentTvdbIdIsNull()
+    public void ReturnsFalseWhenSelectedEpisodeIdIsSetAndCurrentTvdbIdIsNull()
     {
-        // Arrange
-        string input = "12345";
-
         // Act
-        bool result = MatchEpisodeDialog.IsMatchDisabled(input, currentTvdbId: null, isSubmitting: false);
+        bool result = MatchEpisodeDialog.IsMatchDisabled(selectedEpisodeId: 12345, currentTvdbId: null, isSubmitting: false);
 
         // Assert
         result.ShouldBeFalse();
     }
 
     [Fact]
-    public void ReturnsTrueWhenParsedValueEqualsCurrentTvdbId()
+    public void ReturnsTrueWhenSelectedEpisodeIdEqualsCurrentTvdbId()
     {
-        // Arrange
-        string input = "12345";
-
         // Act
-        bool result = MatchEpisodeDialog.IsMatchDisabled(input, currentTvdbId: 12345, isSubmitting: false);
+        bool result = MatchEpisodeDialog.IsMatchDisabled(selectedEpisodeId: 12345, currentTvdbId: 12345, isSubmitting: false);
 
         // Assert
         result.ShouldBeTrue();
     }
 
     [Fact]
-    public void ReturnsFalseWhenParsedValueDiffersFromCurrentTvdbId()
+    public void ReturnsFalseWhenSelectedEpisodeIdDiffersFromCurrentTvdbId()
     {
-        // Arrange
-        string input = "12345";
-
         // Act
-        bool result = MatchEpisodeDialog.IsMatchDisabled(input, currentTvdbId: 99999, isSubmitting: false);
+        bool result = MatchEpisodeDialog.IsMatchDisabled(selectedEpisodeId: 12345, currentTvdbId: 99999, isSubmitting: false);
 
         // Assert
         result.ShouldBeFalse();
     }
 
     [Fact]
-    public void ReturnsTrueWhenIsSubmittingRegardlessOfInput()
+    public void ReturnsTrueWhenIsSubmittingRegardlessOfSelection()
     {
-        // Arrange
-        string input = "12345";
-
         // Act
-        bool result = MatchEpisodeDialog.IsMatchDisabled(input, currentTvdbId: null, isSubmitting: true);
+        bool result = MatchEpisodeDialog.IsMatchDisabled(selectedEpisodeId: 12345, currentTvdbId: null, isSubmitting: true);
 
         // Assert
         result.ShouldBeTrue();

--- a/tests/Ruvarr.UnitTests/Programs/MatchEpisodeDialogTests/ResolveAutoSelectedSeason.cs
+++ b/tests/Ruvarr.UnitTests/Programs/MatchEpisodeDialogTests/ResolveAutoSelectedSeason.cs
@@ -1,0 +1,138 @@
+using Ruvarr.Contracts;
+using Ruvarr.Programs;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.MatchEpisodeDialogTests;
+
+public sealed class ResolveAutoSelectedSeason
+{
+    [Fact]
+    public void ReturnsLowestMatchedSeasonFromSiblings()
+    {
+        // Arrange
+        List<EpisodeSummary> siblings =
+        [
+            CreateEpisode(seasonNumber: 2),
+            CreateEpisode(seasonNumber: 3),
+        ];
+        List<int> availableSeasons = [1, 2, 3];
+
+        // Act
+        int? result = MatchEpisodeDialog.ResolveAutoSelectedSeason(siblings, availableSeasons);
+
+        // Assert
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public void IgnoresSeasonZeroFromSiblings()
+    {
+        // Arrange
+        List<EpisodeSummary> siblings =
+        [
+            CreateEpisode(seasonNumber: 0),
+            CreateEpisode(seasonNumber: 2),
+        ];
+        List<int> availableSeasons = [1, 2];
+
+        // Act
+        int? result = MatchEpisodeDialog.ResolveAutoSelectedSeason(siblings, availableSeasons);
+
+        // Assert
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public void IgnoresNullSeasonFromSiblings()
+    {
+        // Arrange
+        List<EpisodeSummary> siblings =
+        [
+            CreateEpisode(seasonNumber: null),
+            CreateEpisode(seasonNumber: 3),
+        ];
+        List<int> availableSeasons = [1, 2, 3];
+
+        // Act
+        int? result = MatchEpisodeDialog.ResolveAutoSelectedSeason(siblings, availableSeasons);
+
+        // Assert
+        result.ShouldBe(3);
+    }
+
+    [Fact]
+    public void FallsBackToFirstAvailableSeasonWhenNoSiblingMatches()
+    {
+        // Arrange
+        List<EpisodeSummary> siblings = [];
+        List<int> availableSeasons = [1, 2, 3];
+
+        // Act
+        int? result = MatchEpisodeDialog.ResolveAutoSelectedSeason(siblings, availableSeasons);
+
+        // Assert
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public void FallsBackToFirstAvailableSeasonWhenSiblingSeasonNotInAvailable()
+    {
+        // Arrange
+        List<EpisodeSummary> siblings =
+        [
+            CreateEpisode(seasonNumber: 5),
+        ];
+        List<int> availableSeasons = [1, 2, 3];
+
+        // Act
+        int? result = MatchEpisodeDialog.ResolveAutoSelectedSeason(siblings, availableSeasons);
+
+        // Assert
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ReturnsNullWhenNoAvailableSeasons()
+    {
+        // Arrange
+        List<EpisodeSummary> siblings = [];
+        List<int> availableSeasons = [];
+
+        // Act
+        int? result = MatchEpisodeDialog.ResolveAutoSelectedSeason(siblings, availableSeasons);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FallsBackToFirstAvailableWhenAllSiblingsHaveNullSeason()
+    {
+        // Arrange
+        List<EpisodeSummary> siblings =
+        [
+            CreateEpisode(seasonNumber: null),
+            CreateEpisode(seasonNumber: null),
+        ];
+        List<int> availableSeasons = [2, 3];
+
+        // Act
+        int? result = MatchEpisodeDialog.ResolveAutoSelectedSeason(siblings, availableSeasons);
+
+        // Assert
+        result.ShouldBe(2);
+    }
+
+    private static EpisodeSummary CreateEpisode(int? seasonNumber) => new(
+        EpisodeTitle: "Test",
+        EpisodeRuvId: Guid.NewGuid().ToString()[..6],
+        EpisodeDescription: "",
+        TvdbId: seasonNumber is not null ? 100 : null,
+        SeasonNumber: seasonNumber,
+        EpisodeNumber: 1,
+        FirstRun: DateTime.UtcNow,
+        IsMissing: false,
+        RuvUrl: null,
+        DurationSeconds: null);
+}

--- a/tests/Ruvarr.UnitTests/Programs/Queries/GetTvdbSeriesEpisodes/GetTvdbSeriesEpisodesHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Queries/GetTvdbSeriesEpisodes/GetTvdbSeriesEpisodesHandlerTests/Handle.cs
@@ -1,0 +1,152 @@
+using Microsoft.Extensions.Caching.Memory;
+
+using NSubstitute;
+
+using Ruvarr.Contracts;
+using Ruvarr.Infrastructure.Tvdb;
+using Ruvarr.Infrastructure.Tvdb.Models;
+using Ruvarr.Programs.Queries.GetTvdbSeriesEpisodes;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.Queries.GetTvdbSeriesEpisodes.GetTvdbSeriesEpisodesHandlerTests;
+
+public sealed class Handle : IDisposable
+{
+    private readonly ITvdbClient _tvdbClient = Substitute.For<ITvdbClient>();
+    private readonly MemoryCache _cache = new(new MemoryCacheOptions());
+    private readonly GetTvdbSeriesEpisodesHandler _sut;
+
+    public Handle()
+    {
+        _sut = new GetTvdbSeriesEpisodesHandler(_tvdbClient, _cache);
+    }
+
+    [Fact]
+    public async Task ReturnsEpisodesFromTvdbClient()
+    {
+        // Arrange
+        SeriesData seriesData = CreateSeriesData(
+            CreateEpisode(id: 100, name: "Pilot", seasonNumber: 1, number: 1),
+            CreateEpisode(id: 101, name: "Second", seasonNumber: 1, number: 2));
+
+        _tvdbClient.GetSeriesAsync(42, Arg.Any<CancellationToken>()).Returns(seriesData);
+
+        // Act
+        IReadOnlyList<TvdbSeriesEpisode> result = await _sut.Handle(new GetTvdbSeriesEpisodesQuery(42), CancellationToken.None);
+
+        // Assert
+        result.Count.ShouldBe(2);
+        result[0].ShouldBe(new TvdbSeriesEpisode(100, "Pilot", 1, 1));
+        result[1].ShouldBe(new TvdbSeriesEpisode(101, "Second", 1, 2));
+    }
+
+    [Fact]
+    public async Task FiltersOutSeason0Episodes()
+    {
+        // Arrange
+        SeriesData seriesData = CreateSeriesData(
+            CreateEpisode(id: 100, name: "Special", seasonNumber: 0, number: 1),
+            CreateEpisode(id: 101, name: "Pilot", seasonNumber: 1, number: 1));
+
+        _tvdbClient.GetSeriesAsync(42, Arg.Any<CancellationToken>()).Returns(seriesData);
+
+        // Act
+        IReadOnlyList<TvdbSeriesEpisode> result = await _sut.Handle(new GetTvdbSeriesEpisodesQuery(42), CancellationToken.None);
+
+        // Assert
+        result.Count.ShouldBe(1);
+        result[0].TvdbId.ShouldBe(101);
+    }
+
+    [Fact]
+    public async Task ReturnsSortedBySeasonThenEpisode()
+    {
+        // Arrange
+        SeriesData seriesData = CreateSeriesData(
+            CreateEpisode(id: 103, name: "S2E1", seasonNumber: 2, number: 1),
+            CreateEpisode(id: 101, name: "S1E2", seasonNumber: 1, number: 2),
+            CreateEpisode(id: 100, name: "S1E1", seasonNumber: 1, number: 1));
+
+        _tvdbClient.GetSeriesAsync(42, Arg.Any<CancellationToken>()).Returns(seriesData);
+
+        // Act
+        IReadOnlyList<TvdbSeriesEpisode> result = await _sut.Handle(new GetTvdbSeriesEpisodesQuery(42), CancellationToken.None);
+
+        // Assert
+        result[0].TvdbId.ShouldBe(100);
+        result[1].TvdbId.ShouldBe(101);
+        result[2].TvdbId.ShouldBe(103);
+    }
+
+    [Fact]
+    public async Task ReturnsEmptyListWhenSeriesDataIsNull()
+    {
+        // Arrange
+        _tvdbClient.GetSeriesAsync(42, Arg.Any<CancellationToken>()).Returns((SeriesData?)null);
+
+        // Act
+        IReadOnlyList<TvdbSeriesEpisode> result = await _sut.Handle(new GetTvdbSeriesEpisodesQuery(42), CancellationToken.None);
+
+        // Assert
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ReturnsCachedResultOnSecondCall()
+    {
+        // Arrange
+        SeriesData seriesData = CreateSeriesData(
+            CreateEpisode(id: 100, name: "Pilot", seasonNumber: 1, number: 1));
+
+        _tvdbClient.GetSeriesAsync(42, Arg.Any<CancellationToken>()).Returns(seriesData);
+
+        // Act
+        await _sut.Handle(new GetTvdbSeriesEpisodesQuery(42), CancellationToken.None);
+        IReadOnlyList<TvdbSeriesEpisode> result = await _sut.Handle(new GetTvdbSeriesEpisodesQuery(42), CancellationToken.None);
+
+        // Assert
+        result.Count.ShouldBe(1);
+        await _tvdbClient.Received(1).GetSeriesAsync(42, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DifferentSeriesIdsAreNotCachedTogether()
+    {
+        // Arrange
+        _tvdbClient.GetSeriesAsync(42, Arg.Any<CancellationToken>())
+            .Returns(CreateSeriesData(CreateEpisode(id: 100, name: "A", seasonNumber: 1, number: 1)));
+        _tvdbClient.GetSeriesAsync(99, Arg.Any<CancellationToken>())
+            .Returns(CreateSeriesData(CreateEpisode(id: 200, name: "B", seasonNumber: 1, number: 1)));
+
+        // Act
+        IReadOnlyList<TvdbSeriesEpisode> result1 = await _sut.Handle(new GetTvdbSeriesEpisodesQuery(42), CancellationToken.None);
+        IReadOnlyList<TvdbSeriesEpisode> result2 = await _sut.Handle(new GetTvdbSeriesEpisodesQuery(99), CancellationToken.None);
+
+        // Assert
+        result1[0].TvdbId.ShouldBe(100);
+        result2[0].TvdbId.ShouldBe(200);
+    }
+
+    public void Dispose() => _cache.Dispose();
+
+    private static SeriesData CreateSeriesData(params Episode[] episodes)
+    {
+        Series series = new(
+            Id: 1, Name: "Test", Slug: "test", Image: new Uri("http://test.com"),
+            NameTranslations: [], OverviewTranslations: [], Episodes: [],
+            Aliases: [], FirstAired: "", LastAired: "", NextAired: "",
+            Score: 0, Status: new Status(0, "", "", false),
+            OriginalCountry: "", OriginalLanguage: "", IsOrderRandomized: false,
+            LastUpdated: "", AverageRuntime: null, Overview: "", Year: "");
+
+        return new SeriesData(series, episodes);
+    }
+
+    private static Episode CreateEpisode(int id, string name, int seasonNumber, int number) => new(
+        Id: id, SeriesId: 1, Name: name, Overview: "", Aired: "", Runtime: null,
+        NameTranslations: [], OverviewTranslations: [], Image: new Uri("http://test.com"),
+        ImageType: null, IsMovie: 0, Number: number, AbsoluteNumber: 0,
+        SeasonNumber: seasonNumber, LastUpdated: "", FinaleType: null, Year: "",
+        AirsAfterSeason: 0, AirsBeforeSeason: 0, AirsBeforeEpisode: 0);
+}


### PR DESCRIPTION
## Summary
- Replace the free-text TVDB episode ID input in MatchEpisodeDialog with two-step season/episode dropdowns populated from TVDB
- Add `GetTvdbSeriesEpisodesHandler` with 30-minute `IMemoryCache` caching
- Auto-select season based on sibling episode matches or program's SeasonNumber
- Auto-select episode when title matches "Þáttur x" pattern
- Add accessible loading states, error handling, and empty state messaging
- Add comprehensive unit tests (handler, auto-selection, component tests)

## Test plan
- [x] All 471 tests pass (434 unit + 37 integration)
- [x] Build passes with zero warnings
- [x] Security review: no blocking findings
- [x] Performance review: no blocking findings
- [x] UX review: all blocking findings resolved

Closes #97