### PR TITLE
feat: add TVDB create button for unmatched programs

### DIFF
--- a/src/Ruvarr/Components/Icon.razor
+++ b/src/Ruvarr/Components/Icon.razor
@@ -53,6 +53,10 @@
             <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
             <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
             break;
+        case IconType.Plus:
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+            break;
         case IconType.Refresh:
             <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
             <path d="M3 3v5h5" />

--- a/src/Ruvarr/Components/IconType.cs
+++ b/src/Ruvarr/Components/IconType.cs
@@ -13,6 +13,7 @@ public enum IconType
     EyeOff,
     Link,
     LinkDiagonal,
+    Plus,
     Refresh,
     Spinner,
     Warning

--- a/src/Ruvarr/Programs/ProgramDetail.razor
+++ b/src/Ruvarr/Programs/ProgramDetail.razor
@@ -73,7 +73,7 @@ else
             }
         </div>
         <h1>@_program.ProgramName</h1>
-        @if (_program.SeriesName is not null || _program.RuvUrl is not null)
+        @if (_program.SeriesName is not null || _program.RuvUrl is not null || _program.TvdbSeriesId is null)
         {
             <div class="series-meta">
                 @if (_program.SeriesName is not null)
@@ -87,6 +87,12 @@ else
                 @if (_program.RuvUrl is not null)
                 {
                     <a class="badge--ruv" href="@_program.RuvUrl" target="_blank" rel="noopener noreferrer">RÚV</a>
+                }
+                @if (_program.TvdbSeriesId is null)
+                {
+                    <button class="badge--tvdb-create" @onclick="CreateOnTvdb" title="Create series on TVDB">
+                        <Icon Type="IconType.Plus" Width="12" Height="12" /> TVDB
+                    </button>
                 }
             </div>
         }
@@ -360,6 +366,21 @@ else
     private async Task OpenMatchDialog(string ruvId, int? currentTvdbId, string episodeTitle)
     {
         await _matchDialog!.OpenAsync(ruvId, currentTvdbId, _program!.TvdbSeriesId!.Value, episodeTitle, _episodes!);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
+    private async Task CreateOnTvdb()
+    {
+        string clipboardText = $"Name: {_program!.ProgramName}\nNetwork: RÚV\nRemote ID: {_program.ProgramRuvId} (RÚV)";
+        try
+        {
+            await Js.InvokeVoidAsync("copyToClipboard", clipboardText);
+        }
+        catch (JSException)
+        {
+            // Clipboard access may be denied; still open the page
+        }
+        await Js.InvokeVoidAsync("open", "https://thetvdb.com/series/create", "_blank");
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]

--- a/src/Ruvarr/wwwroot/app.css
+++ b/src/Ruvarr/wwwroot/app.css
@@ -732,6 +732,28 @@ dialog input[type="number"]:focus {
     opacity: 0.8;
 }
 
+.badge--tvdb-create {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border-radius: 4px;
+    border: 1px dashed #60a5fa;
+    color: #60a5fa;
+    background: none;
+    cursor: pointer;
+    margin-bottom: 0.5rem;
+    transition: background-color 0.15s ease, opacity 0.15s ease;
+}
+
+.badge--tvdb-create:hover {
+    background-color: rgba(96, 165, 250, 0.1);
+}
+
 .dialog-select {
     background-color: #1a1a1a;
     border: 1px solid rgba(255, 255, 255, 0.2);


### PR DESCRIPTION
## Summary
- Show a dashed "TVDB" badge on program detail page when no TVDB series is linked
- Clicking the button copies program metadata (name, network, RUV ID) to clipboard and opens the TVDB series creation page
- Add `Plus` icon type to the `Icon` component

## Test plan
- [ ] Navigate to a program that has no TVDB series linked
- [ ] Verify the dashed "TVDB" badge appears in the series-meta row
- [ ] Click the button and confirm clipboard contains program metadata
- [ ] Confirm TVDB create page opens in a new tab
- [ ] Verify the button does not appear for programs already matched to TVDB