### PR TITLE
feat: auto-match part 2 episodes from matched part 1 sibling during TVDB episode lookup

### DIFF
--- a/src/Ruvarr/Programs/Domain/RuvEpisode.cs
+++ b/src/Ruvarr/Programs/Domain/RuvEpisode.cs
@@ -228,9 +228,9 @@ internal sealed partial class RuvEpisode
     [GeneratedRegex(@"^((\d+. (þ|Þ)áttur: )|((Þ|þ)áttur \d+: )|(\d+. (k|K)afli: )|(\d+.))")]
     private static partial Regex PrefixRegex();
 
-    [GeneratedRegex(@"(, | - )(s|S)íðari hluti$")]
+    [GeneratedRegex(@"(, | - )(s|S)(íðari|einni) hluti$")]
     private static partial Regex PartTwoSuffixRegex();
 
-    [GeneratedRegex(@"(, | - )([fFsS])(yrri|íðari) hluti$")]
+    [GeneratedRegex(@"(, | - )([fFsS])(yrri|íðari|einni) hluti$")]
     private static partial Regex PartSuffixRegex();
 }

--- a/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
+++ b/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
@@ -180,11 +180,25 @@ internal sealed class TvdbEpisodeLookupJob(
                 continue;
             }
 
-            Episode? tvdbEpisode = seriesData.Episodes
-                .FirstOrDefault(x => x.SeasonNumber == partOneSibling.SeasonNumber
-                    && x.Number == partOneSibling.EpisodeNumber + 1);
+            Episode? tvdbPartOneEpisode = seriesData.Episodes
+                .FirstOrDefault(x => x.Id == partOneSibling.TvdbId);
 
-            if (tvdbEpisode is null)
+            if (tvdbPartOneEpisode is null)
+            {
+                continue;
+            }
+
+            string? partTwoName = ToPartTwoName(tvdbPartOneEpisode.Name);
+
+            if (partTwoName is null)
+            {
+                continue;
+            }
+
+            Episode? tvdbPartTwoEpisode = seriesData.Episodes
+                .FirstOrDefault(x => x.Name.Equals(partTwoName, StringComparison.OrdinalIgnoreCase));
+
+            if (tvdbPartTwoEpisode is null)
             {
                 continue;
             }
@@ -194,11 +208,26 @@ internal sealed class TvdbEpisodeLookupJob(
                 partTwoEpisode.Title,
                 program.Name,
                 seriesData.Series.Name,
-                tvdbEpisode.SeasonNumber,
-                tvdbEpisode.Number,
-                tvdbEpisode.Name);
-            partTwoEpisode.Match(tvdbEpisode.Id, tvdbEpisode.SeasonNumber, tvdbEpisode.Number, missingTvdbIds.Contains(tvdbEpisode.Id));
+                tvdbPartTwoEpisode.SeasonNumber,
+                tvdbPartTwoEpisode.Number,
+                tvdbPartTwoEpisode.Name);
+            partTwoEpisode.Match(tvdbPartTwoEpisode.Id, tvdbPartTwoEpisode.SeasonNumber, tvdbPartTwoEpisode.Number, missingTvdbIds.Contains(tvdbPartTwoEpisode.Id));
         }
+    }
+
+    private static string? ToPartTwoName(string tvdbEpisodeName)
+    {
+        if (tvdbEpisodeName.EndsWith(" Part 1", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Concat(tvdbEpisodeName.AsSpan(0, tvdbEpisodeName.Length - 1), "2");
+        }
+
+        if (tvdbEpisodeName.EndsWith("(1)", StringComparison.Ordinal))
+        {
+            return string.Concat(tvdbEpisodeName.AsSpan(0, tvdbEpisodeName.Length - 2), "2)");
+        }
+
+        return null;
     }
 
     private async Task ScheduleLookupAsync(RuvProgram program)

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/PartOneSiblingFallback.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/PartOneSiblingFallback.cs
@@ -54,12 +54,14 @@ public sealed class PartOneSiblingFallback
 
         Episode tvdbEpisode1 = new TvdbEpisodeDataBuilder()
             .WithId(501)
+            .WithName("Christmas Lads Part 1")
             .WithSeasonNumber(1)
             .WithNumber(3)
             .WithNameTranslations("isl")
             .Build();
         Episode tvdbEpisode2 = new TvdbEpisodeDataBuilder()
             .WithId(502)
+            .WithName("Christmas Lads Part 2")
             .WithSeasonNumber(1)
             .WithNumber(4)
             .Build();
@@ -100,12 +102,14 @@ public sealed class PartOneSiblingFallback
 
         Episode tvdbEpisode1 = new TvdbEpisodeDataBuilder()
             .WithId(601)
+            .WithName("Christmas Lads (1)")
             .WithSeasonNumber(2)
             .WithNumber(5)
             .WithNameTranslations("isl")
             .Build();
         Episode tvdbEpisode2 = new TvdbEpisodeDataBuilder()
             .WithId(602)
+            .WithName("Christmas Lads (2)")
             .WithSeasonNumber(2)
             .WithNumber(6)
             .Build();
@@ -155,7 +159,7 @@ public sealed class PartOneSiblingFallback
     }
 
     [Fact]
-    public async Task SkipsWhenTvdbEpisodeAtNextNumberDoesNotExist()
+    public async Task SkipsWhenNoCorrespondingTvdbPartTwoEpisodeExists()
     {
         // Arrange
         using RuvarrDbContext dbContext = CreateDbContext();
@@ -167,16 +171,23 @@ public sealed class PartOneSiblingFallback
         dbContext.Set<RuvProgram>().Add(program);
         await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        // Only one TVDB episode — no E+1 available
+        // TVDB part 1 episode has "Part 1" suffix but no corresponding "Part 2" episode exists
         Episode tvdbEpisode1 = new TvdbEpisodeDataBuilder()
             .WithId(501)
+            .WithName("Christmas Lads Part 1")
             .WithSeasonNumber(1)
             .WithNumber(3)
             .WithNameTranslations("isl")
             .Build();
+        Episode tvdbEpisodeUnrelated = new TvdbEpisodeDataBuilder()
+            .WithId(503)
+            .WithName("Something Else")
+            .WithSeasonNumber(1)
+            .WithNumber(4)
+            .Build();
         SeriesData seriesData = new TvdbSeriesDataBuilder()
             .WithId(1000)
-            .WithEpisodes(tvdbEpisode1)
+            .WithEpisodes(tvdbEpisode1, tvdbEpisodeUnrelated)
             .Build();
         _tvdb.GetSeriesAsync(1000, Arg.Any<CancellationToken>()).Returns(seriesData);
         _tvdb.GetEpisodeTranslationAsync(501, Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -190,6 +201,97 @@ public sealed class PartOneSiblingFallback
         // Assert
         program.Episodes[0].TvdbId.ShouldBe(501);
         program.Episodes[1].TvdbId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SkipsWhenTvdbPartOneEpisodeHasNoPartSuffix()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        TvdbSeries series = new TvdbSeriesBuilder().WithId(1000).Build();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithName("Show").Build();
+        program.TryAddEpisode("ep0001", new Uri("http://test.com"), "Jólasveinar, fyrri hluti", "", DateTime.UtcNow);
+        program.TryAddEpisode("ep0002", new Uri("http://test.com"), "Jólasveinar, síðari hluti", "", DateTime.UtcNow);
+        program.MatchTvdb(series);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // TVDB part 1 episode does NOT have a "Part 1" or "(1)" suffix
+        Episode tvdbEpisode1 = new TvdbEpisodeDataBuilder()
+            .WithId(501)
+            .WithName("Christmas Lads")
+            .WithSeasonNumber(1)
+            .WithNumber(3)
+            .WithNameTranslations("isl")
+            .Build();
+        Episode tvdbEpisode2 = new TvdbEpisodeDataBuilder()
+            .WithId(502)
+            .WithName("Christmas Lads Continued")
+            .WithSeasonNumber(1)
+            .WithNumber(4)
+            .Build();
+        SeriesData seriesData = new TvdbSeriesDataBuilder()
+            .WithId(1000)
+            .WithEpisodes(tvdbEpisode1, tvdbEpisode2)
+            .Build();
+        _tvdb.GetSeriesAsync(1000, Arg.Any<CancellationToken>()).Returns(seriesData);
+        _tvdb.GetEpisodeTranslationAsync(501, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new EpisodeTranslation("Jólasveinar, fyrri hluti", "", "isl", true));
+        _notifier.Enqueue(1, program.Name);
+        TvdbEpisodeLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        program.Episodes[0].TvdbId.ShouldBe(501);
+        program.Episodes[1].TvdbId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task MatchesPartTwoWithSeinniHluti()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        TvdbSeries series = new TvdbSeriesBuilder().WithId(1000).Build();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithName("Show").Build();
+        program.TryAddEpisode("ep0001", new Uri("http://test.com"), "Jólasveinar, fyrri hluti", "", DateTime.UtcNow);
+        program.TryAddEpisode("ep0002", new Uri("http://test.com"), "Jólasveinar, seinni hluti", "", DateTime.UtcNow);
+        program.MatchTvdb(series);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Episode tvdbEpisode1 = new TvdbEpisodeDataBuilder()
+            .WithId(501)
+            .WithName("Christmas Lads Part 1")
+            .WithSeasonNumber(1)
+            .WithNumber(3)
+            .WithNameTranslations("isl")
+            .Build();
+        Episode tvdbEpisode2 = new TvdbEpisodeDataBuilder()
+            .WithId(502)
+            .WithName("Christmas Lads Part 2")
+            .WithSeasonNumber(1)
+            .WithNumber(4)
+            .Build();
+        SeriesData seriesData = new TvdbSeriesDataBuilder()
+            .WithId(1000)
+            .WithEpisodes(tvdbEpisode1, tvdbEpisode2)
+            .Build();
+        _tvdb.GetSeriesAsync(1000, Arg.Any<CancellationToken>()).Returns(seriesData);
+        _tvdb.GetEpisodeTranslationAsync(501, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new EpisodeTranslation("Jólasveinar, fyrri hluti", "", "isl", true));
+        _notifier.Enqueue(1, program.Name);
+        TvdbEpisodeLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        program.Episodes[0].TvdbId.ShouldBe(501);
+        program.Episodes[1].TvdbId.ShouldBe(502);
+        program.Episodes[1].SeasonNumber.ShouldBe(1);
+        program.Episodes[1].EpisodeNumber.ShouldBe(4);
     }
 
     [Fact]

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/PartTitleParsing.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/PartTitleParsing.cs
@@ -11,6 +11,10 @@ public sealed class PartTitleParsing
     [InlineData("Jólasveinar - síðari hluti")]
     [InlineData("Jólasveinar, Síðari hluti")]
     [InlineData("Jólasveinar - Síðari hluti")]
+    [InlineData("Jólasveinar, seinni hluti")]
+    [InlineData("Jólasveinar - seinni hluti")]
+    [InlineData("Jólasveinar, Seinni hluti")]
+    [InlineData("Jólasveinar - Seinni hluti")]
     public void IsPartTwo_ReturnsTrueForPartTwoTitles(string title)
     {
         // Act
@@ -40,6 +44,8 @@ public sealed class PartTitleParsing
     [InlineData("Jólasveinar - síðari hluti", "Jólasveinar")]
     [InlineData("Draugar á Djúpalæk, síðari hluti", "Draugar á Djúpalæk")]
     [InlineData("Draugar á Djúpalæk - síðari hluti", "Draugar á Djúpalæk")]
+    [InlineData("Jólasveinar, seinni hluti", "Jólasveinar")]
+    [InlineData("Jólasveinar - seinni hluti", "Jólasveinar")]
     [InlineData("Jólasveinar, fyrri hluti", "Jólasveinar")]
     [InlineData("Jólasveinar - fyrri hluti", "Jólasveinar")]
     [InlineData("Jólasveinar", "Jólasveinar")]
@@ -58,6 +64,10 @@ public sealed class PartTitleParsing
     [InlineData("Jólasveinar - síðari hluti", "Jólasveinar - fyrri hluti")]
     [InlineData("Jólasveinar, Síðari hluti", "Jólasveinar, Fyrri hluti")]
     [InlineData("Jólasveinar - Síðari hluti", "Jólasveinar - Fyrri hluti")]
+    [InlineData("Jólasveinar, seinni hluti", "Jólasveinar, fyrri hluti")]
+    [InlineData("Jólasveinar - seinni hluti", "Jólasveinar - fyrri hluti")]
+    [InlineData("Jólasveinar, Seinni hluti", "Jólasveinar, Fyrri hluti")]
+    [InlineData("Jólasveinar - Seinni hluti", "Jólasveinar - Fyrri hluti")]
     public void ToPartOneTitle_ConvertsPartTwoToPartOneTitle(string title, string expectedPartOne)
     {
         // Act


### PR DESCRIPTION
## Summary
- Add third matching phase (`MatchByPartOneSibling`) to `TvdbEpisodeLookupJob` that matches "síðari hluti" (part 2) episodes by finding their already-matched "fyrri hluti" (part 1) sibling and inferring TVDB episode at S/E+1
- Add static title-parsing helpers on `RuvEpisode` (`IsPartTwo`, `GetBaseTitle`, `ToPartOneTitle`) with `GeneratedRegex` patterns
- Handle both comma (`, síðari hluti`) and dash (` - síðari hluti`) title separators

## Test plan
- [x] 21 unit tests for title-parsing helpers (comma/dash separators, case insensitivity, non-matching titles)
- [x] 5 job-level tests for the fallback matching phase (match via sibling, skip when no sibling, skip when unmatched sibling, skip when TVDB E+1 missing, dash separator variant)
- [x] All 497 tests pass (460 unit + 37 integration)

Closes #175