### PR TITLE
Fix flaky domain event broadcaster tests in CI

### DIFF
--- a/src/Ruvarr/Abstractions/DomainEventBroadcaster.cs
+++ b/src/Ruvarr/Abstractions/DomainEventBroadcaster.cs
@@ -25,7 +25,7 @@ internal sealed class DomainEventBroadcaster : IDomainEventBroadcaster
         }
     }
 
-    public async IAsyncEnumerable<TEvent> Subscribe<TEvent>([EnumeratorCancellation] CancellationToken cancellationToken) where TEvent : class
+    public IAsyncEnumerable<TEvent> Subscribe<TEvent>(CancellationToken cancellationToken) where TEvent : class
     {
         Channel<TEvent> channel = Channel.CreateUnbounded<TEvent>();
         List<object> channels = _subscribers.GetOrAdd(typeof(TEvent), _ => []);
@@ -35,6 +35,15 @@ internal sealed class DomainEventBroadcaster : IDomainEventBroadcaster
             channels.Add(channel);
         }
 
+        return ReadChannel(channel, channels, _lock, cancellationToken);
+    }
+
+    private static async IAsyncEnumerable<TEvent> ReadChannel<TEvent>(
+        Channel<TEvent> channel,
+        List<object> channels,
+        Lock @lock,
+        [EnumeratorCancellation] CancellationToken cancellationToken) where TEvent : class
+    {
         await using CancellationTokenRegistration registration = cancellationToken.Register(
             () => channel.Writer.TryComplete());
 
@@ -50,7 +59,7 @@ internal sealed class DomainEventBroadcaster : IDomainEventBroadcaster
         }
         finally
         {
-            lock (_lock)
+            lock (@lock)
             {
                 channels.Remove(channel);
             }

--- a/tests/Ruvarr.UnitTests/Abstractions/DomainEventBroadcasterTests/Publish.cs
+++ b/tests/Ruvarr.UnitTests/Abstractions/DomainEventBroadcasterTests/Publish.cs
@@ -16,16 +16,15 @@ public sealed class Publish
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
 
         TestEventWithValue? received = null;
+        IAsyncEnumerable<TestEventWithValue> subscription = sut.Subscribe<TestEventWithValue>(cts.Token);
         Task subscribeTask = Task.Run(async () =>
         {
-            await foreach (TestEventWithValue e in sut.Subscribe<TestEventWithValue>(cts.Token))
+            await foreach (TestEventWithValue e in subscription)
             {
                 received = e;
                 await cts.CancelAsync();
             }
         }, cts.Token);
-
-        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act
         sut.Publish(new TestEventWithValue("hello"));
@@ -47,25 +46,25 @@ public sealed class Publish
         TestEventWithValue? received1 = null;
         TestEventWithValue? received2 = null;
 
+        IAsyncEnumerable<TestEventWithValue> subscription1 = sut.Subscribe<TestEventWithValue>(cts1.Token);
         Task sub1 = Task.Run(async () =>
         {
-            await foreach (TestEventWithValue e in sut.Subscribe<TestEventWithValue>(cts1.Token))
+            await foreach (TestEventWithValue e in subscription1)
             {
                 received1 = e;
                 await cts1.CancelAsync();
             }
         }, cts1.Token);
 
+        IAsyncEnumerable<TestEventWithValue> subscription2 = sut.Subscribe<TestEventWithValue>(cts2.Token);
         Task sub2 = Task.Run(async () =>
         {
-            await foreach (TestEventWithValue e in sut.Subscribe<TestEventWithValue>(cts2.Token))
+            await foreach (TestEventWithValue e in subscription2)
             {
                 received2 = e;
                 await cts2.CancelAsync();
             }
         }, cts2.Token);
-
-        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act
         sut.Publish(new TestEventWithValue("multi"));
@@ -97,16 +96,15 @@ public sealed class Publish
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
 
         EventA? received = null;
+        IAsyncEnumerable<EventA> subscription = sut.Subscribe<EventA>(cts.Token);
         _ = Task.Run(async () =>
         {
-            await foreach (EventA e in sut.Subscribe<EventA>(cts.Token))
+            await foreach (EventA e in subscription)
             {
                 received = e;
                 await cts.CancelAsync();
             }
         }, cts.Token);
-
-        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act
         sut.Publish(new EventB(1));
@@ -125,17 +123,16 @@ public sealed class Publish
         using CancellationTokenSource cts = new();
 
         bool completed = false;
+        IAsyncEnumerable<TestEventWithValue> subscription = sut.Subscribe<TestEventWithValue>(cts.Token);
         Task subscribeTask = Task.Run(async () =>
         {
             int count = 0;
-            await foreach (TestEventWithValue _ in sut.Subscribe<TestEventWithValue>(cts.Token))
+            await foreach (TestEventWithValue _ in subscription)
             {
                 count++;
             }
             completed = count == 0;
         }, CancellationToken.None);
-
-        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act
         await cts.CancelAsync();

--- a/tests/Ruvarr.UnitTests/Programs/EpisodeAddedToMatchedProgramEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/EpisodeAddedToMatchedProgramEventHandlerTests/Handle.cs
@@ -38,16 +38,16 @@ public sealed class Handle
 
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
         QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>? received = null;
+        IAsyncEnumerable<QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>> subscription =
+            broadcaster.Subscribe<QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>>(cts.Token);
         Task watchTask = Task.Run(async () =>
         {
-            await foreach (QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary> e in broadcaster.Subscribe<QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>>(cts.Token))
+            await foreach (QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary> e in subscription)
             {
                 received = e;
                 await cts.CancelAsync();
             }
         }, cts.Token);
-
-        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act
         await sut.Handle(@event, TestContext.Current.CancellationToken);

--- a/tests/Ruvarr.UnitTests/Programs/EpisodeMatchedEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/EpisodeMatchedEventHandlerTests/Handle.cs
@@ -21,16 +21,15 @@ public sealed class Handle
         using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
 
         EpisodeMatchedEvent? received = null;
+        IAsyncEnumerable<EpisodeMatchedEvent> subscription = broadcaster.Subscribe<EpisodeMatchedEvent>(cts.Token);
         Task watchTask = Task.Run(async () =>
         {
-            await foreach (EpisodeMatchedEvent e in broadcaster.Subscribe<EpisodeMatchedEvent>(cts.Token))
+            await foreach (EpisodeMatchedEvent e in subscription)
             {
                 received = e;
                 await cts.CancelAsync();
             }
         }, TestContext.Current.CancellationToken);
-
-        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act
         await sut.Handle(@event, TestContext.Current.CancellationToken);

--- a/tests/Ruvarr.UnitTests/Programs/ProgramCreatedEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramCreatedEventHandlerTests/Handle.cs
@@ -21,16 +21,15 @@ public sealed class Handle
         using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
 
         ProgramCreatedEvent? received = null;
+        IAsyncEnumerable<ProgramCreatedEvent> subscription = broadcaster.Subscribe<ProgramCreatedEvent>(cts.Token);
         Task watchTask = Task.Run(async () =>
         {
-            await foreach (ProgramCreatedEvent e in broadcaster.Subscribe<ProgramCreatedEvent>(cts.Token))
+            await foreach (ProgramCreatedEvent e in subscription)
             {
                 received = e;
                 await cts.CancelAsync();
             }
         }, TestContext.Current.CancellationToken);
-
-        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act
         await sut.Handle(@event, TestContext.Current.CancellationToken);

--- a/tests/Ruvarr.UnitTests/Programs/ProgramMatchedTmdbEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramMatchedTmdbEventHandlerTests/Handle.cs
@@ -17,16 +17,15 @@ public sealed class Handle
 
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
         ProgramMatchedTmdbEvent? received = null;
+        IAsyncEnumerable<ProgramMatchedTmdbEvent> subscription = broadcaster.Subscribe<ProgramMatchedTmdbEvent>(cts.Token);
         Task watchTask = Task.Run(async () =>
         {
-            await foreach (ProgramMatchedTmdbEvent e in broadcaster.Subscribe<ProgramMatchedTmdbEvent>(cts.Token))
+            await foreach (ProgramMatchedTmdbEvent e in subscription)
             {
                 received = e;
                 await cts.CancelAsync();
             }
         }, cts.Token);
-
-        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act
         await sut.Handle(@event, TestContext.Current.CancellationToken);

--- a/tests/Ruvarr.UnitTests/Programs/ProgramMatchedTvdbEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramMatchedTvdbEventHandlerTests/Handle.cs
@@ -38,16 +38,16 @@ public sealed class Handle
 
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
         QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>? received = null;
+        IAsyncEnumerable<QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>> subscription =
+            broadcaster.Subscribe<QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>>(cts.Token);
         Task watchTask = Task.Run(async () =>
         {
-            await foreach (QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary> e in broadcaster.Subscribe<QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>>(cts.Token))
+            await foreach (QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary> e in subscription)
             {
                 received = e;
                 await cts.CancelAsync();
             }
         }, cts.Token);
-
-        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act
         await sut.Handle(@event, TestContext.Current.CancellationToken);

--- a/tests/Ruvarr.UnitTests/Programs/ProgramRefreshRequestedEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramRefreshRequestedEventHandlerTests/Handle.cs
@@ -45,16 +45,16 @@ public sealed class Handle
 
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
         QueueChangedEvent<ProgramRefreshQueueItemSummary>? received = null;
+        IAsyncEnumerable<QueueChangedEvent<ProgramRefreshQueueItemSummary>> subscription =
+            _broadcaster.Subscribe<QueueChangedEvent<ProgramRefreshQueueItemSummary>>(cts.Token);
         Task watchTask = Task.Run(async () =>
         {
-            await foreach (QueueChangedEvent<ProgramRefreshQueueItemSummary> e in _broadcaster.Subscribe<QueueChangedEvent<ProgramRefreshQueueItemSummary>>(cts.Token))
+            await foreach (QueueChangedEvent<ProgramRefreshQueueItemSummary> e in subscription)
             {
                 received = e;
                 await cts.CancelAsync();
             }
         }, cts.Token);
-
-        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act
         await sut.Handle(@event, TestContext.Current.CancellationToken);


### PR DESCRIPTION
## Summary
- Refactored `DomainEventBroadcaster.Subscribe<T>()` from an async iterator to eager channel registration, eliminating the race condition that caused intermittent CI failures
- Removed `Task.Delay(50)` workarounds from all 7 affected test files since the channel is now guaranteed to be registered before `Subscribe` returns

## Test plan
- [x] All unit tests pass consistently across 5 consecutive runs
- [x] Security review — no issues found
- [x] Performance review — no issues found

Closes #181