### PR TITLE
fix(ui): reorder and compact icon columns in programs table

### DIFF
--- a/src/Ruvarr/Programs/Programs.razor
+++ b/src/Ruvarr/Programs/Programs.razor
@@ -81,10 +81,10 @@ else
                 <tr>
                     <th>Program</th>
                     <th>Channel</th>
-                    <th class="col-center">Monitored</th>
-                    <th class="col-center">Missing</th>
                     <th>TVDB Series</th>
-                    <th class="col-center">Matched</th>
+                    <th class="col-center"></th>
+                    <th class="col-center"></th>
+                    <th class="col-center"></th>
                     <th></th>
                 </tr>
             </thead>
@@ -93,22 +93,6 @@ else
                     <tr @key="program.ProgramRuvId">
                         <td><a class="program-link" href="/program/@program.ProgramRuvId">@program.ProgramName</a></td>
                         <td><span class="channel-tag">@program.Channel</span></td>
-                        <td class="col-center">
-                            @if (program.IsMonitored)
-                            {
-                                <Icon Type="IconType.Eye" Class="icon icon--monitored" AriaLabel="Monitored" />
-                            }
-                            else
-                            {
-                                <Icon Type="IconType.EyeOff" Class="icon icon--unmonitored" AriaLabel="Unmonitored" />
-                            }
-                        </td>
-                        <td class="col-center">
-                            @if (program.HasMissingEpisodes)
-                            {
-                                <Icon Type="IconType.Warning" Class="icon icon--missing" AriaLabel="Missing episodes" />
-                            }
-                        </td>
                         <td>
                             @if (program.TvdbUrl is not null)
                             {
@@ -124,6 +108,22 @@ else
                             }
                         </td>
                         <td class="col-center">
+                            @if (program.HasMissingEpisodes)
+                            {
+                                <span title="Missing episodes"><Icon Type="IconType.Warning" Class="icon icon--missing" AriaLabel="Missing episodes" /></span>
+                            }
+                        </td>
+                        <td class="col-center">
+                            @if (program.IsMonitored)
+                            {
+                                <span title="Monitored"><Icon Type="IconType.Eye" Class="icon icon--monitored" AriaLabel="Monitored" /></span>
+                            }
+                            else
+                            {
+                                <span title="Unmonitored"><Icon Type="IconType.EyeOff" Class="icon icon--unmonitored" AriaLabel="Unmonitored" /></span>
+                            }
+                        </td>
+                        <td class="col-center">
                             @{
                                 (string cssClass, string ariaLabel) = program.EpisodeMatchStatus switch
                                 {
@@ -132,7 +132,7 @@ else
                                     _ => ("icon--matched-none", "No episodes matched"),
                                 };
                             }
-                            <Icon Type="IconType.CheckmarkCircle" Class="@($"icon {cssClass}")" AriaLabel="@ariaLabel" />
+                            <span title="@ariaLabel"><Icon Type="IconType.CheckmarkCircle" Class="@($"icon {cssClass}")" AriaLabel="@ariaLabel" /></span>
                         </td>
                         <td>
                             <div class="row-actions">
@@ -150,13 +150,13 @@ else
                                 }
                                 @if (_refreshQueue.TryGetValue(program.ProgramRuvId, out ProgramRefreshStatus status) && status == ProgramRefreshStatus.Processing)
                                 {
-                                    <span class="icon-button">
+                                    <span class="icon-button" title="Refreshing">
                                         <Icon Type="IconType.Spinner" Class="icon icon--spinning" AriaLabel="Refreshing" />
                                     </span>
                                 }
                                 else if (_refreshQueue.ContainsKey(program.ProgramRuvId) || _pendingRefresh.Contains(program.ProgramRuvId))
                                 {
-                                    <span class="icon-button">
+                                    <span class="icon-button" title="Queued for refresh">
                                         <Icon Type="IconType.Clock" Class="icon" AriaLabel="Pending" />
                                     </span>
                                 }

--- a/src/Ruvarr/wwwroot/app.css
+++ b/src/Ruvarr/wwwroot/app.css
@@ -509,16 +509,19 @@ dialog input[type="number"]:focus {
 .programs-table td:nth-child(2) { width: 7rem; }
 
 .programs-table th:nth-child(3),
-.programs-table td:nth-child(3) { width: 7rem; white-space: unset; text-align: center; }
+.programs-table td:nth-child(3) { width: 16rem; }
 
 .programs-table th:nth-child(4),
-.programs-table td:nth-child(4) { width: 6rem; text-align: center; }
+.programs-table td:nth-child(4) { width: 1%; white-space: nowrap; text-align: center; }
 
 .programs-table th:nth-child(5),
-.programs-table td:nth-child(5) { width: 16rem; }
+.programs-table td:nth-child(5) { width: 1%; white-space: nowrap; text-align: center; }
 
 .programs-table th:nth-child(6),
-.programs-table td:nth-child(6) { width: 6rem; text-align: center; }
+.programs-table td:nth-child(6) { width: 1%; white-space: nowrap; text-align: center; }
+
+.programs-table th:nth-child(7),
+.programs-table td:nth-child(7) { width: 1%; white-space: nowrap; }
 
 .col-center { text-align: center; }
 .col-center svg { display: block; margin: 0 auto; }


### PR DESCRIPTION
## Summary
- Reorder programs table columns: Program | Channel | TVDB Series | Missing | Monitored | Matched | Actions
- Remove text headings from indicator icon columns, add tooltips to all icons (indicators and action buttons)
- Shrink icon and action columns to content width using `width: 1%; white-space: nowrap`

## Test plan
- [ ] Verify programs table columns display in correct order
- [ ] Hover over indicator icons to confirm tooltips appear (Missing episodes, Monitored/Unmonitored, match status)
- [ ] Hover over action buttons to confirm tooltips (Match to TVDB, View on RÚV, Refresh, Refreshing, Queued for refresh)
- [ ] Verify icon columns are compact and don't take excess width