### PR TITLE
Add match/fix match button to programs list and detail views

### DIFF
--- a/src/Ruvarr/Programs/MatchProgramDialog.razor
+++ b/src/Ruvarr/Programs/MatchProgramDialog.razor
@@ -8,7 +8,7 @@
 @inject IJSRuntime Js
 
 <dialog @ref="_dialog" @onclose="OnDialogClose">
-    <h2>Match to TVDB</h2>
+    <h2>@(_isFixMatch ? "Fix Match" : "Match to TVDB")</h2>
     @if (_isLoadingSuggestions)
     {
         <div class="dialog-spinner-container" role="status" aria-label="Loading suggestions">
@@ -65,6 +65,7 @@
     private int? _ruvId;
     private string _tvdbIdInput = string.Empty;
     private int? _currentTvdbSeriesId;
+    private bool _isFixMatch;
     private bool _isSubmitting;
     private string? _errorMessage;
     private readonly CancellationTokenSource _cts = new();
@@ -74,9 +75,10 @@
     private bool _searchFailed;
     private bool _hasSearched;
 
-    public async Task OpenAsync(int ruvId, int? currentTvdbSeriesId, string programName)
+    public async Task OpenAsync(int ruvId, int? currentTvdbSeriesId, string programName, bool isFixMatch)
     {
         _ruvId = ruvId;
+        _isFixMatch = isFixMatch;
         _currentTvdbSeriesId = currentTvdbSeriesId;
         _tvdbIdInput = currentTvdbSeriesId?.ToString() ?? string.Empty;
         _errorMessage = null;
@@ -126,6 +128,7 @@
     private void OnDialogClose()
     {
         _ruvId = null;
+        _isFixMatch = false;
         _currentTvdbSeriesId = null;
         _tvdbIdInput = string.Empty;
         _suggestions = [];

--- a/src/Ruvarr/Programs/ProgramDetail.razor
+++ b/src/Ruvarr/Programs/ProgramDetail.razor
@@ -9,6 +9,7 @@
 @using Ruvarr.ProgramRefreshQueue.Notifiers
 @using Ruvarr.Programs.Events
 @using Ruvarr.Programs.Commands.DownloadEpisode
+@using Ruvarr.Programs.Commands.MatchProgram
 @using Ruvarr.Programs.Commands.RefreshProgram
 @using Ruvarr.Programs.Queries.GetProgram
 @using Ruvarr.Programs.Queries.GetProgramEpisodes
@@ -73,35 +74,35 @@ else
             }
         </div>
         <h1>@_program.ProgramName</h1>
-        @if (_program.SeriesName is not null || _program.RuvUrl is not null || _program.TvdbSeriesId is null)
-        {
-            <div class="series-meta">
-                @if (_program.SeriesName is not null)
-                {
-                    <span class="series-name">@_program.SeriesName</span>
-                }
-                @if (_program.TvdbUrl is not null)
-                {
-                    <a class="badge--tvdb" href="@_program.TvdbUrl" target="_blank" rel="noopener noreferrer">TVDB</a>
-                }
-                @if (_program.RuvUrl is not null)
-                {
-                    <a class="badge--ruv" href="@_program.RuvUrl" target="_blank" rel="noopener noreferrer">RÚV</a>
-                }
-                @if (_program.TvdbSeriesId is null)
-                {
-                    <button class="badge--tvdb-create" @onclick="CreateOnTvdb" title="Create series on TVDB">
-                        <Icon Type="IconType.Plus" Width="12" Height="12" /> TVDB
-                    </button>
-                }
-                @if (_program.TvdbSeriesId is not null && !_program.IsMonitored && !_program.IsMovieMatch)
-                {
-                    <button class="action-button" @onclick="OpenAddToSonarrDialog">
-                        <Icon Type="IconType.Plus" Width="12" Height="12" /> Add to Sonarr
-                    </button>
-                }
-            </div>
-        }
+        <div class="series-meta">
+            @if (_program.SeriesName is not null)
+            {
+                <span class="series-name">@_program.SeriesName</span>
+            }
+            @if (_program.TvdbUrl is not null)
+            {
+                <a class="badge--tvdb" href="@_program.TvdbUrl" target="_blank" rel="noopener noreferrer">TVDB</a>
+            }
+            @if (_program.RuvUrl is not null)
+            {
+                <a class="badge--ruv" href="@_program.RuvUrl" target="_blank" rel="noopener noreferrer">RÚV</a>
+            }
+            @if (_program.TvdbSeriesId is null)
+            {
+                <button class="badge--tvdb-create" @onclick="CreateOnTvdb" title="Create series on TVDB">
+                    <Icon Type="IconType.Plus" Width="12" Height="12" /> TVDB
+                </button>
+            }
+            <button class="action-button" @onclick="OpenMatchProgramDialog" title="@GetMatchButtonLabel(_program.TvdbSeriesId, _program.IsMovieMatch)">
+                <Icon Type="IconType.Link" Width="12" Height="12" /> @GetMatchButtonLabel(_program.TvdbSeriesId, _program.IsMovieMatch)
+            </button>
+            @if (_program.TvdbSeriesId is not null && !_program.IsMonitored && !_program.IsMovieMatch)
+            {
+                <button class="action-button" @onclick="OpenAddToSonarrDialog">
+                    <Icon Type="IconType.Plus" Width="12" Height="12" /> Add to Sonarr
+                </button>
+            }
+        </div>
     </div>
 
     @if (!string.IsNullOrWhiteSpace(_program.Description))
@@ -227,6 +228,7 @@ else
     }
 }
 
+<MatchProgramDialog @ref="_matchProgramDialog" OnMatchComplete="ReloadProgramAsync" />
 <MatchEpisodeDialog @ref="_matchDialog" OnMatchComplete="ReloadEpisodesAsync" />
 <AddToSonarrDialog @ref="_addToSonarrDialog" OnAddComplete="ReloadProgramAsync" />
 
@@ -245,6 +247,7 @@ else
     private Dictionary<int, ProgramRefreshStatus> _refreshQueue = [];
     private readonly CancellationTokenSource _cts = new();
 
+    private MatchProgramDialog? _matchProgramDialog;
     private MatchEpisodeDialog? _matchDialog;
     private AddToSonarrDialog? _addToSonarrDialog;
     private DateTime _lastEpisodeReloadTime;
@@ -381,6 +384,18 @@ else
     private async Task OpenMatchDialog(string ruvId, int? currentTvdbId, string episodeTitle)
     {
         await _matchDialog!.OpenAsync(ruvId, currentTvdbId, _program!.TvdbSeriesId!.Value, episodeTitle, _episodes!);
+    }
+
+    internal static string GetMatchButtonLabel(int? tvdbSeriesId, bool isMovieMatch)
+    {
+        return tvdbSeriesId is null && !isMovieMatch ? "Match" : "Fix Match";
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
+    private async Task OpenMatchProgramDialog()
+    {
+        bool isFixMatch = _program!.TvdbSeriesId is not null || _program.IsMovieMatch;
+        await _matchProgramDialog!.OpenAsync(_program.ProgramRuvId, _program.TvdbSeriesId, _program.ProgramName, isFixMatch);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]

--- a/src/Ruvarr/Programs/Programs.razor
+++ b/src/Ruvarr/Programs/Programs.razor
@@ -191,12 +191,9 @@ else
                         </td>
                         <td>
                             <div class="row-actions">
-                                @if (program.TvdbSeriesId is null)
-                                {
-                                    <button class="icon-button" @onclick="() => OpenMatchProgramDialog(program)" title="Match to TVDB">
-                                        <Icon Type="IconType.Link" Class="icon" AriaLabel="Match to TVDB" />
-                                    </button>
-                                }
+                                <button class="icon-button" @onclick="() => OpenMatchProgramDialog(program)" title="@GetMatchButtonLabel(program.TvdbSeriesId, program.IsMovieMatch)">
+                                    <Icon Type="IconType.Link" Class="icon" AriaLabel="@GetMatchButtonLabel(program.TvdbSeriesId, program.IsMovieMatch)" />
+                                </button>
                                 @if (program.RuvUrl is not null)
                                 {
                                     <a class="icon-button" href="@program.RuvUrl" target="_blank" rel="noopener noreferrer" title="View on RÚV">
@@ -456,10 +453,16 @@ else
         await LoadProgramsAsync();
     }
 
+    internal static string GetMatchButtonLabel(int? tvdbSeriesId, bool isMovieMatch)
+    {
+        return tvdbSeriesId is null && !isMovieMatch ? "Match" : "Fix Match";
+    }
+
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
     private async Task OpenMatchProgramDialog(ProgramSummary program)
     {
-        await _matchProgramDialog!.OpenAsync(program.ProgramRuvId, program.TvdbSeriesId, program.ProgramName);
+        bool isFixMatch = program.TvdbSeriesId is not null || program.IsMovieMatch;
+        await _matchProgramDialog!.OpenAsync(program.ProgramRuvId, program.TvdbSeriesId, program.ProgramName, isFixMatch);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]

--- a/src/Ruvarr/wwwroot/app.css
+++ b/src/Ruvarr/wwwroot/app.css
@@ -231,6 +231,11 @@ tbody tr:hover {
     background-color: rgba(255, 255, 255, 0.1);
 }
 
+.icon-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.6);
+    outline-offset: 1px;
+}
+
 .icon-button--error {
     color: #fd4646;
 }

--- a/tests/Ruvarr.UnitTests/Programs/MatchProgramDialogTests/DialogTitle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/MatchProgramDialogTests/DialogTitle.cs
@@ -1,0 +1,62 @@
+using Bunit;
+
+using Microsoft.JSInterop;
+
+using NSubstitute;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Contracts;
+using Ruvarr.Programs;
+using Ruvarr.Programs.Commands.MatchProgram;
+using Ruvarr.Programs.Queries.SearchTvdbSeries;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.MatchProgramDialogTests;
+
+public sealed class DialogTitle : BunitContext
+{
+    public DialogTitle()
+    {
+        IRequestHandler<MatchProgramCommand> matchHandler = Substitute.For<IRequestHandler<MatchProgramCommand>>();
+        matchHandler
+            .Handle(Arg.Any<MatchProgramCommand>(), Arg.Any<CancellationToken>())
+            .Returns(RuvarrResult.Success);
+        Services.AddTransient(_ => matchHandler);
+
+        IRequestHandler<SearchTvdbSeriesQuery, IReadOnlyList<TvdbSeriesSuggestion>> searchHandler =
+            Substitute.For<IRequestHandler<SearchTvdbSeriesQuery, IReadOnlyList<TvdbSeriesSuggestion>>>();
+        searchHandler
+            .Handle(Arg.Any<SearchTvdbSeriesQuery>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<TvdbSeriesSuggestion>)[]);
+        Services.AddTransient(_ => searchHandler);
+
+        Services.AddSingleton(Substitute.For<IJSRuntime>());
+    }
+
+    [Fact]
+    public async Task ShowsMatchToTvdbWhenIsFixMatchIsFalse()
+    {
+        // Arrange
+        IRenderedComponent<MatchProgramDialog> cut = Render<MatchProgramDialog>();
+
+        // Act
+        await cut.Instance.OpenAsync(ruvId: 1, currentTvdbSeriesId: null, programName: "Test Program", isFixMatch: false);
+
+        // Assert
+        cut.Find("h2").TextContent.ShouldBe("Match to TVDB");
+    }
+
+    [Fact]
+    public async Task ShowsFixMatchWhenIsFixMatchIsTrue()
+    {
+        // Arrange
+        IRenderedComponent<MatchProgramDialog> cut = Render<MatchProgramDialog>();
+
+        // Act
+        await cut.Instance.OpenAsync(ruvId: 1, currentTvdbSeriesId: 12345, programName: "Test Program", isFixMatch: true);
+
+        // Assert
+        cut.Find("h2").TextContent.ShouldBe("Fix Match");
+    }
+}

--- a/tests/Ruvarr.UnitTests/Programs/MatchProgramDialogTests/SubmitMatch.cs
+++ b/tests/Ruvarr.UnitTests/Programs/MatchProgramDialogTests/SubmitMatch.cs
@@ -47,7 +47,7 @@ public sealed class SubmitMatch : BunitContext
             .Returns(RuvarrResult.Failure(error));
 
         IRenderedComponent<MatchProgramDialog> cut = Render<MatchProgramDialog>();
-        await cut.Instance.OpenAsync(ruvId: 1, currentTvdbSeriesId: null, programName: "Test Program");
+        await cut.Instance.OpenAsync(ruvId: 1, currentTvdbSeriesId: null, programName: "Test Program", isFixMatch: false);
         await cut.Find("input").InputAsync(new ChangeEventArgs { Value = "12345" });
 
         // Act
@@ -67,13 +67,13 @@ public sealed class SubmitMatch : BunitContext
             .Returns(RuvarrResult.Failure(error));
 
         IRenderedComponent<MatchProgramDialog> cut = Render<MatchProgramDialog>();
-        await cut.Instance.OpenAsync(ruvId: 1, currentTvdbSeriesId: null, programName: "Test Program");
+        await cut.Instance.OpenAsync(ruvId: 1, currentTvdbSeriesId: null, programName: "Test Program", isFixMatch: false);
         await cut.Find("input").InputAsync(new ChangeEventArgs { Value = "12345" });
         await cut.Find("button.dialog-button--primary").ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
         cut.Markup.ShouldContain("Something went wrong.");
 
         // Act
-        await cut.Instance.OpenAsync(ruvId: 1, currentTvdbSeriesId: null, programName: "Test Program");
+        await cut.Instance.OpenAsync(ruvId: 1, currentTvdbSeriesId: null, programName: "Test Program", isFixMatch: false);
 
         // Assert
         cut.Markup.ShouldNotContain("Something went wrong.");

--- a/tests/Ruvarr.UnitTests/Programs/ProgramDetailTests/GetMatchButtonLabel.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramDetailTests/GetMatchButtonLabel.cs
@@ -1,0 +1,64 @@
+using Ruvarr.Programs;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.ProgramDetailTests;
+
+public sealed class GetMatchButtonLabel
+{
+    [Fact]
+    public void ReturnsMatchWhenTvdbSeriesIdIsNullAndIsNotMovieMatch()
+    {
+        // Arrange
+        int? tvdbSeriesId = null;
+        bool isMovieMatch = false;
+
+        // Act
+        string result = ProgramDetail.GetMatchButtonLabel(tvdbSeriesId, isMovieMatch);
+
+        // Assert
+        result.ShouldBe("Match");
+    }
+
+    [Fact]
+    public void ReturnsFixMatchWhenTvdbSeriesIdHasValue()
+    {
+        // Arrange
+        int? tvdbSeriesId = 12345;
+        bool isMovieMatch = false;
+
+        // Act
+        string result = ProgramDetail.GetMatchButtonLabel(tvdbSeriesId, isMovieMatch);
+
+        // Assert
+        result.ShouldBe("Fix Match");
+    }
+
+    [Fact]
+    public void ReturnsFixMatchWhenIsMovieMatch()
+    {
+        // Arrange
+        int? tvdbSeriesId = null;
+        bool isMovieMatch = true;
+
+        // Act
+        string result = ProgramDetail.GetMatchButtonLabel(tvdbSeriesId, isMovieMatch);
+
+        // Assert
+        result.ShouldBe("Fix Match");
+    }
+
+    [Fact]
+    public void ReturnsFixMatchWhenBothTvdbSeriesIdHasValueAndIsMovieMatch()
+    {
+        // Arrange
+        int? tvdbSeriesId = 12345;
+        bool isMovieMatch = true;
+
+        // Act
+        string result = ProgramDetail.GetMatchButtonLabel(tvdbSeriesId, isMovieMatch);
+
+        // Assert
+        result.ShouldBe("Fix Match");
+    }
+}

--- a/tests/Ruvarr.UnitTests/Programs/ProgramsPageTests/GetMatchButtonLabel.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramsPageTests/GetMatchButtonLabel.cs
@@ -1,0 +1,64 @@
+using Shouldly;
+
+using ProgramsPage = Ruvarr.Programs.Programs;
+
+namespace Ruvarr.UnitTests.Programs.ProgramsPageTests;
+
+public sealed class GetMatchButtonLabel
+{
+    [Fact]
+    public void ReturnsMatchWhenTvdbSeriesIdIsNullAndIsNotMovieMatch()
+    {
+        // Arrange
+        int? tvdbSeriesId = null;
+        bool isMovieMatch = false;
+
+        // Act
+        string result = ProgramsPage.GetMatchButtonLabel(tvdbSeriesId, isMovieMatch);
+
+        // Assert
+        result.ShouldBe("Match");
+    }
+
+    [Fact]
+    public void ReturnsFixMatchWhenTvdbSeriesIdHasValue()
+    {
+        // Arrange
+        int? tvdbSeriesId = 12345;
+        bool isMovieMatch = false;
+
+        // Act
+        string result = ProgramsPage.GetMatchButtonLabel(tvdbSeriesId, isMovieMatch);
+
+        // Assert
+        result.ShouldBe("Fix Match");
+    }
+
+    [Fact]
+    public void ReturnsFixMatchWhenIsMovieMatch()
+    {
+        // Arrange
+        int? tvdbSeriesId = null;
+        bool isMovieMatch = true;
+
+        // Act
+        string result = ProgramsPage.GetMatchButtonLabel(tvdbSeriesId, isMovieMatch);
+
+        // Assert
+        result.ShouldBe("Fix Match");
+    }
+
+    [Fact]
+    public void ReturnsFixMatchWhenBothTvdbSeriesIdHasValueAndIsMovieMatch()
+    {
+        // Arrange
+        int? tvdbSeriesId = 12345;
+        bool isMovieMatch = true;
+
+        // Act
+        string result = ProgramsPage.GetMatchButtonLabel(tvdbSeriesId, isMovieMatch);
+
+        // Assert
+        result.ShouldBe("Fix Match");
+    }
+}


### PR DESCRIPTION
## Summary
- Add Match/Fix Match button to programs list and program detail views
- Button shows "Match" for unmatched programs, "Fix Match" for already-matched programs
- Clicking opens the existing MatchProgramDialog with contextual title
- Add `:focus-visible` to `.icon-button` for WCAG 2.4.7 keyboard accessibility

## Test plan
- [x] 10 new bUnit tests (GetMatchButtonLabel x8, DialogTitle x2)
- [x] All 595 tests pass (547 unit + 48 integration)
- [x] Security review: no blocking findings
- [x] Performance review: no blocking findings
- [x] UX review: 2 blocking findings fixed and verified

Closes #169