### PR TITLE
Replace Episodes spread copy with AsReadOnly() wrapper

### DIFF
--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -55,7 +55,7 @@ internal sealed class RuvProgram
 
     public TmdbMovie? Movie { get; private set; }
 
-    public IReadOnlyList<RuvEpisode> Episodes => [.. _episodes];
+    public IReadOnlyList<RuvEpisode> Episodes => _episodes.AsReadOnly();
 
     public int SeasonNumber
     {


### PR DESCRIPTION
## Summary
- Replace `[.. _episodes]` spread operator with `_episodes.AsReadOnly()` in `RuvProgram.Episodes` property to eliminate unnecessary list allocation on every access
- Returns a lightweight read-only view instead of copying the backing list, improving performance in hot paths like `TvdbEpisodeLookupJob` (6+ accesses per invocation)

## Test plan
- [x] All 596 existing tests pass (548 unit + 48 integration)
- [x] Build clean with 0 warnings
- [x] Verified no callers rely on getting a mutable copy
- [x] Security review: Low severity finding noted (live view vs snapshot) — mitigated by existing job concurrency model
- [x] Performance review: No issues

Closes #177