### PR TITLE
Parallelize TVDB translation lookups in episode matching

### DIFF
--- a/src/Ruvarr/Infrastructure/Tvdb/ServiceCollectionExtensions.cs
+++ b/src/Ruvarr/Infrastructure/Tvdb/ServiceCollectionExtensions.cs
@@ -13,7 +13,6 @@ internal static class ServiceCollectionExtensions
         IOptions<TvdbOptions> options = services.BuildServiceProvider()
             .GetRequiredService<IOptions<TvdbOptions>>();
 
-        services.AddTransient<ITvdbClient, TvdbClient>();
         services.AddHttpClient<ITvdbClient, TvdbClient>(client => client.BaseAddress = options.Value.BaseAddress);
 
         return services;

--- a/src/Ruvarr/Infrastructure/Tvdb/TvdbClient.cs
+++ b/src/Ruvarr/Infrastructure/Tvdb/TvdbClient.cs
@@ -7,8 +7,11 @@ using Ruvarr.Infrastructure.Tvdb.Models;
 
 namespace Ruvarr.Infrastructure.Tvdb;
 
-internal sealed class TvdbClient(HttpClient client, IMemoryCache memoryCache, IOptions<TvdbOptions> options) : ITvdbClient
+internal sealed class TvdbClient(HttpClient client, IMemoryCache memoryCache, IOptions<TvdbOptions> options) : ITvdbClient, IDisposable
 {
+    private readonly SemaphoreSlim _loginSemaphore = new(1, 1);
+
+    public void Dispose() => _loginSemaphore.Dispose();
     public async Task<SearchResponse> SearchAsync(
         string? query = null,
         string? type = null,
@@ -37,54 +40,87 @@ internal sealed class TvdbClient(HttpClient client, IMemoryCache memoryCache, IO
             .WithLimit(limit)
             .Build();
 
-        await SetAuthorizationHeader(cancellationToken);
+        string token = await GetAccessTokenAsync(cancellationToken);
 
-        SearchResponse response = await client.GetFromJsonAsync<SearchResponse>(path, cancellationToken)
+        using HttpRequestMessage request = new(HttpMethod.Get, path);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<SearchResponse>(cancellationToken)
             ?? throw new InvalidOperationException("Failed to search the TVDB");
-
-        return response;
     }
 
     public async Task<SeriesData?> GetSeriesAsync(int id, CancellationToken cancellationToken = default)
     {
-        await SetAuthorizationHeader(cancellationToken);
+        string token = await GetAccessTokenAsync(cancellationToken);
 
-        SeriesResponse? response = await client.GetFromJsonAsync<SeriesResponse>($"v4/series/{id}/episodes/default", cancellationToken);
+        using HttpRequestMessage request = new(HttpMethod.Get, $"v4/series/{id}/episodes/default");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        return response?.Data;
+        HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        SeriesResponse? seriesResponse = await response.Content.ReadFromJsonAsync<SeriesResponse>(cancellationToken);
+
+        return seriesResponse?.Data;
     }
 
     public async Task<Episode?> GetEpisodeAsync(int id, CancellationToken cancellationToken = default)
     {
-        await SetAuthorizationHeader(cancellationToken);
+        string token = await GetAccessTokenAsync(cancellationToken);
 
-        TvdbResponse<Episode?>? response = await client.GetFromJsonAsync<TvdbResponse<Episode?>>(
-            $"v4/episodes/{id}",
-            cancellationToken);
+        using HttpRequestMessage request = new(HttpMethod.Get, $"v4/episodes/{id}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        return response?.Data;
+        HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        TvdbResponse<Episode?>? episodeResponse = await response.Content.ReadFromJsonAsync<TvdbResponse<Episode?>>(cancellationToken);
+
+        return episodeResponse?.Data;
     }
 
     public async Task<EpisodeTranslation?> GetEpisodeTranslationAsync(int id, string language = "isl", CancellationToken cancellationToken = default)
     {
-        await SetAuthorizationHeader(cancellationToken);
+        string token = await GetAccessTokenAsync(cancellationToken);
 
-        TvdbResponse<EpisodeTranslation?>? response = await client.GetFromJsonAsync<TvdbResponse<EpisodeTranslation?>>(
-            $"v4/episodes/{id}/translations/{language}",
-            cancellationToken);
+        using HttpRequestMessage request = new(HttpMethod.Get, $"v4/episodes/{id}/translations/{language}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        return response?.Data;
+        HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        TvdbResponse<EpisodeTranslation?>? translationResponse = await response.Content.ReadFromJsonAsync<TvdbResponse<EpisodeTranslation?>>(cancellationToken);
+
+        return translationResponse?.Data;
     }
 
-    private async Task SetAuthorizationHeader(CancellationToken cancellationToken)
+    private async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)
     {
-        if (!memoryCache.TryGetValue(TvdbOptions.AccessTokenCacheKey, out string? accessToken))
+        if (memoryCache.TryGetValue(TvdbOptions.AccessTokenCacheKey, out string? accessToken))
         {
+            return accessToken!;
+        }
+
+        await _loginSemaphore.WaitAsync(cancellationToken);
+        try
+        {
+            if (memoryCache.TryGetValue(TvdbOptions.AccessTokenCacheKey, out accessToken))
+            {
+                return accessToken!;
+            }
+
             AuthenticationResponse? response = await LoginAsync(options.Value.ApiKey, null, cancellationToken);
 
             if (string.IsNullOrWhiteSpace(response?.Data.Token))
             {
-                return;
+                throw new InvalidOperationException("Failed to authenticate with the TVDB");
             }
 
             accessToken = response.Data.Token;
@@ -96,10 +132,13 @@ internal sealed class TvdbClient(HttpClient client, IMemoryCache memoryCache, IO
                 Size = 1
             };
             memoryCache.Set(TvdbOptions.AccessTokenCacheKey, accessToken, cacheOptions);
+
+            return accessToken;
         }
-
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-
+        finally
+        {
+            _loginSemaphore.Release();
+        }
     }
 
     private async Task<AuthenticationResponse?> LoginAsync(string apiKey, string? pin = null, CancellationToken cancellationToken = default)

--- a/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
+++ b/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 using Microsoft.EntityFrameworkCore;
 
 using Quartz;
@@ -81,16 +83,25 @@ internal sealed class TvdbEpisodeLookupJob(
             .Where(x => x.NameTranslations.Contains("isl"))];
         logger.LogDebug("Found {Count} episodes with Icelandic titles", translatedEpisodes.Count);
 
-        foreach (Episode translatedEpisode in translatedEpisodes)
-        {
-            logger.LogDebug(
-                "Querying TVDB translation for {SeriesName} S{Season:D2}E{Episode:D2} {EpisodeName}",
-                seriesData.Series.Name,
-                translatedEpisode.SeasonNumber,
-                translatedEpisode.Number,
-                translatedEpisode.Name);
-            EpisodeTranslation? translation = await tvdb.GetEpisodeTranslationAsync(translatedEpisode.Id);
+        ConcurrentBag<(Episode Episode, EpisodeTranslation? Translation)> translations = [];
 
+        await Parallel.ForEachAsync(
+            translatedEpisodes,
+            new ParallelOptions { MaxDegreeOfParallelism = 3 },
+            async (translatedEpisode, cancellationToken) =>
+            {
+                logger.LogDebug(
+                    "Querying TVDB translation for {SeriesName} S{Season:D2}E{Episode:D2} {EpisodeName}",
+                    seriesData.Series.Name,
+                    translatedEpisode.SeasonNumber,
+                    translatedEpisode.Number,
+                    translatedEpisode.Name);
+                EpisodeTranslation? translation = await tvdb.GetEpisodeTranslationAsync(translatedEpisode.Id, cancellationToken: cancellationToken);
+                translations.Add((translatedEpisode, translation));
+            });
+
+        foreach ((Episode translatedEpisode, EpisodeTranslation? translation) in translations)
+        {
             if (translation is null)
             {
                 logger.LogDebug("TVDB episode translation not found");

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/TitleMatching.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/TitleMatching.cs
@@ -156,6 +156,48 @@ public sealed class TitleMatching
     }
 
     [Fact]
+    public async Task FetchesAllTranslationsForMultipleEpisodes()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        TvdbSeries series = new TvdbSeriesBuilder().WithId(1000).Build();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).Build();
+        program.TryAddEpisode("ep0001", new Uri("http://test.com"), "Þáttur 1", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("ep0002", new Uri("http://test.com"), "Þáttur 2", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("ep0003", new Uri("http://test.com"), "Þáttur 3", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.MatchTvdb(series);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Episode tvdbEpisode1 = new TvdbEpisodeDataBuilder()
+            .WithId(101).WithSeasonNumber(1).WithNumber(1).WithNameTranslations("isl").Build();
+        Episode tvdbEpisode2 = new TvdbEpisodeDataBuilder()
+            .WithId(102).WithSeasonNumber(1).WithNumber(2).WithNameTranslations("isl").Build();
+        Episode tvdbEpisode3 = new TvdbEpisodeDataBuilder()
+            .WithId(103).WithSeasonNumber(1).WithNumber(3).WithNameTranslations("isl").Build();
+        SeriesData seriesData = new TvdbSeriesDataBuilder()
+            .WithId(1000).WithEpisodes(tvdbEpisode1, tvdbEpisode2, tvdbEpisode3).Build();
+        _tvdb.GetSeriesAsync(1000, Arg.Any<CancellationToken>()).Returns(seriesData);
+        _tvdb.GetEpisodeTranslationAsync(101, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new EpisodeTranslation("Þáttur 1", "", "isl", true));
+        _tvdb.GetEpisodeTranslationAsync(102, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new EpisodeTranslation("Þáttur 2", "", "isl", true));
+        _tvdb.GetEpisodeTranslationAsync(103, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new EpisodeTranslation("Þáttur 3", "", "isl", true));
+        _notifier.Enqueue(1, program.Name);
+        TvdbEpisodeLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        program.Episodes[0].TvdbId.ShouldBe(101);
+        program.Episodes[1].TvdbId.ShouldBe(102);
+        program.Episodes[2].TvdbId.ShouldBe(103);
+        await _tvdb.Received(3).GetEpisodeTranslationAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task SetsIsMissingWhenTvdbIdIsInSonarrList()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Replace sequential HTTP calls in `MatchByTranslationAsync` with `Parallel.ForEachAsync` (max degree 3) for translation fetches, followed by sequential matching to keep EF Core mutations thread-safe
- Make `TvdbClient` thread-safe for concurrent use: per-request `HttpRequestMessage` headers instead of mutating shared `DefaultRequestHeaders`, `SemaphoreSlim` with double-check locking for token acquisition
- Remove redundant `AddTransient` registration that shadowed the `AddHttpClient` typed client registration

## Test plan
- [x] All 597 existing tests pass (549 unit + 48 integration)
- [x] Build clean with 0 warnings
- [x] New test `FetchesAllTranslationsForMultipleEpisodes` validates multi-episode matching correctness
- [x] Security review: all findings resolved (race condition on `DefaultRequestHeaders`, duplicate registration)
- [x] Performance review: all findings resolved (race condition, concurrent login)

Closes #178