### PR TITLE
Use HashSet for matchedIds in TvdbEpisodeLookupJob

### DIFF
--- a/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
+++ b/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
@@ -75,7 +75,7 @@ internal sealed class TvdbEpisodeLookupJob(
 
     private async Task MatchByTranslationAsync(RuvProgram program, SeriesData seriesData, HashSet<int> missingTvdbIds)
     {
-        List<int> matchedIds = [.. program.Episodes.Select(x => x.TvdbId).OfType<int>()];
+        HashSet<int> matchedIds = [.. program.Episodes.Select(x => x.TvdbId).OfType<int>()];
 
         logger.LogDebug("Series {Name} has {Count} episodes", seriesData.Series.Name, seriesData.Episodes.Count);
         List<Episode> translatedEpisodes = [.. seriesData.Episodes

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/TitleMatching.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/TitleMatching.cs
@@ -230,4 +230,39 @@ public sealed class TitleMatching
         // Assert
         program.Episodes[0].IsMissing.ShouldBeTrue();
     }
+
+    [Fact]
+    public async Task SkipsTranslationLookupForAlreadyMatchedEpisodes()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        TvdbSeries series = new TvdbSeriesBuilder().WithId(1000).Build();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).Build();
+        program.TryAddEpisode("ep0001", new Uri("http://test.com"), "Þáttur 1", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("ep0002", new Uri("http://test.com"), "Þáttur 2", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.MatchTvdb(series);
+        program.Episodes[0].Match(101, 1, 1, false);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Episode tvdbEpisode1 = new TvdbEpisodeDataBuilder()
+            .WithId(101).WithSeasonNumber(1).WithNumber(1).WithNameTranslations("isl").Build();
+        Episode tvdbEpisode2 = new TvdbEpisodeDataBuilder()
+            .WithId(102).WithSeasonNumber(1).WithNumber(2).WithNameTranslations("isl").Build();
+        SeriesData seriesData = new TvdbSeriesDataBuilder()
+            .WithId(1000).WithEpisodes(tvdbEpisode1, tvdbEpisode2).Build();
+        _tvdb.GetSeriesAsync(1000, Arg.Any<CancellationToken>()).Returns(seriesData);
+        _tvdb.GetEpisodeTranslationAsync(102, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new EpisodeTranslation("Þáttur 2", "", "isl", true));
+        _notifier.Enqueue(1, program.Name);
+        TvdbEpisodeLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        await _tvdb.DidNotReceive().GetEpisodeTranslationAsync(101, Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _tvdb.Received(1).GetEpisodeTranslationAsync(102, Arg.Any<string>(), Arg.Any<CancellationToken>());
+        program.Episodes[1].TvdbId.ShouldBe(102);
+    }
 }


### PR DESCRIPTION
## Summary
- Replace `List<int>` with `HashSet<int>` for `matchedIds` in `TvdbEpisodeLookupJob.MatchByTranslationAsync()` to get O(1) `.Contains()` lookups instead of O(n), consistent with the existing `missingTvdbIds` pattern
- Add test verifying already-matched episodes are skipped during translation lookups

## Test plan
- [x] New test `SkipsTranslationLookupForAlreadyMatchedEpisodes` passes
- [x] All 598 existing tests pass
- [x] Build clean with zero warnings

Closes #179