### PR TITLE
Disambiguate TVDB series matches by episode translations

### DIFF
--- a/src/Ruvarr/TvdbSeriesLookup/Jobs/TvdbSeriesLookupJob.cs
+++ b/src/Ruvarr/TvdbSeriesLookup/Jobs/TvdbSeriesLookupJob.cs
@@ -37,6 +37,7 @@ internal sealed class TvdbSeriesLookupJob(
 
         RuvProgram? program = await dbContext.Set<RuvProgram>()
             .Include(x => x.Series)
+            .Include(x => x.Episodes)
             .Where(x => x.RuvId == ruvId)
             .FirstOrDefaultAsync();
 
@@ -69,10 +70,14 @@ internal sealed class TvdbSeriesLookupJob(
             return;
         }
 
-        Datum? match = await SearchTvdbAsync(program.Name, checkTranslations: true)
-            ?? await TryRemovingNumeralEnding(program.Name, checkTranslations: true)
-            ?? await SearchTvdbAsync(program.ForeignName, checkTranslations: false)
-            ?? await TryRemovingNumeralEnding(program.ForeignName, checkTranslations: false);
+        IReadOnlyList<RuvEpisode> episodes = program.Episodes;
+
+        CancellationToken cancellationToken = context.CancellationToken;
+
+        Datum? match = await SearchTvdbAsync(program.Name, checkTranslations: true, episodes: episodes, cancellationToken)
+            ?? await TryRemovingNumeralEnding(program.Name, checkTranslations: true, episodes: episodes, cancellationToken)
+            ?? await SearchTvdbAsync(program.ForeignName, checkTranslations: false, episodes: episodes, cancellationToken)
+            ?? await TryRemovingNumeralEnding(program.ForeignName, checkTranslations: false, episodes: episodes, cancellationToken);
 
         if (match is null)
         {
@@ -124,16 +129,16 @@ internal sealed class TvdbSeriesLookupJob(
         (d.Name.HasYearSuffix() && d.Name.WithoutYearSuffix()!.EqualsSanitized(searchText))
         || (d.Translations.TryGetValue("isl", out string? islName) && islName.HasYearSuffix() && islName.WithoutYearSuffix()!.EqualsSanitized(searchText)));
 
-    private Task<Datum?> TryRemovingNumeralEnding(string? searchText, bool checkTranslations)
+    private Task<Datum?> TryRemovingNumeralEnding(string? searchText, bool checkTranslations, IReadOnlyList<RuvEpisode> episodes, CancellationToken cancellationToken)
     {
         string? trimmed = searchText.WithoutNumeralEnding();
 
         return searchText == trimmed
             ? Task.FromResult(default(Datum?))
-            : SearchTvdbAsync(trimmed, checkTranslations);
+            : SearchTvdbAsync(trimmed, checkTranslations, episodes, cancellationToken);
     }
 
-    private async Task<Datum?> SearchTvdbAsync(string? searchText, bool checkTranslations)
+    private async Task<Datum?> SearchTvdbAsync(string? searchText, bool checkTranslations, IReadOnlyList<RuvEpisode> episodes, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(searchText))
         {
@@ -149,7 +154,7 @@ internal sealed class TvdbSeriesLookupJob(
 
         logger.LogDebug("Searching TVDB for series '{Name}'", searchText);
 
-        SearchResponse response = await tvdb.SearchAsync(query: sanitizedSearchText);
+        SearchResponse response = await tvdb.SearchAsync(query: sanitizedSearchText, cancellationToken: cancellationToken);
 
         List<Datum> data = [.. response.Data.Where(x => x.Type.Equals("series", StringComparison.OrdinalIgnoreCase))];
         List<Datum> matches = [];
@@ -172,6 +177,84 @@ internal sealed class TvdbSeriesLookupJob(
             return null;
         }
 
+        if (matches.Count > 1 && episodes.Count > 0)
+        {
+            return await DisambiguateByEpisodeTranslationsAsync(matches, episodes, cancellationToken);
+        }
+
         return matches.Count == 1 ? matches[0] : null;
+    }
+
+    private async Task<Datum?> DisambiguateByEpisodeTranslationsAsync(List<Datum> candidates, IReadOnlyList<RuvEpisode> episodes, CancellationToken cancellationToken)
+    {
+        Datum? winner = null;
+
+        foreach (Datum candidate in candidates)
+        {
+            if (!int.TryParse(candidate.TvdbId, NumberStyles.Integer, CultureInfo.InvariantCulture, out int candidateTvdbId) || candidateTvdbId < 1)
+            {
+                continue;
+            }
+
+            SeriesData? seriesData = await tvdb.GetSeriesAsync(candidateTvdbId, cancellationToken: cancellationToken);
+
+            if (seriesData is null)
+            {
+                continue;
+            }
+
+            List<Episode> translatedEpisodes = [.. seriesData.Episodes
+                .Where(x => x.NameTranslations.Contains("isl"))];
+
+            if (translatedEpisodes.Count == 0)
+            {
+                continue;
+            }
+
+            bool hasMatch = false;
+
+            using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            try
+            {
+                await Parallel.ForEachAsync(
+                    translatedEpisodes,
+                    new ParallelOptions { MaxDegreeOfParallelism = 3, CancellationToken = linkedCts.Token },
+                    async (translatedEpisode, loopToken) =>
+                    {
+                        EpisodeTranslation? translation = await tvdb.GetEpisodeTranslationAsync(translatedEpisode.Id, cancellationToken: loopToken);
+
+                        if (translation is not null
+                            && !string.IsNullOrWhiteSpace(translation.Name)
+                            && episodes.Any(e => e.IsMatch(translation.Name)))
+                        {
+                            hasMatch = true;
+                            await linkedCts.CancelAsync();
+                        }
+                    });
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Expected when short-circuiting after finding a match
+            }
+
+            if (hasMatch)
+            {
+                if (winner is not null)
+                {
+                    logger.LogDebug("Multiple candidates matched episode translations for disambiguation — returning null");
+                    return null;
+                }
+
+                winner = candidate;
+            }
+        }
+
+        if (winner is not null)
+        {
+            logger.LogDebug("Disambiguated by episode translations — selected candidate '{Name}' (TvdbId: {TvdbId})", winner.Name, winner.TvdbId);
+        }
+
+        return winner;
     }
 }

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbSeriesLookupJobTests/SearchTvdbAsync.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbSeriesLookupJobTests/SearchTvdbAsync.cs
@@ -260,6 +260,232 @@ public sealed class SearchTvdbAsync
     }
 
     [Fact]
+    public async Task DisambiguatesByEpisodeTranslation_WhenMultipleExactMatches_AndSingleCandidateMatchesEpisode()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Katla")
+            .WithForeignName(null)
+            .Build();
+        program.TryAddEpisode("ep1", new Uri("http://test.com"), "Eldur", "desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Datum match1 = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("100")
+            .Build();
+        Datum match2 = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("200")
+            .Build();
+
+        _tvdb.SearchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(CreateSearchResponse(match1, match2));
+
+        Episode tvdbEp1 = new TvdbEpisodeDataBuilder()
+            .WithId(10)
+            .WithName("Fire")
+            .WithNameTranslations("isl")
+            .WithSeasonNumber(1)
+            .WithNumber(1)
+            .Build();
+        SeriesData series100 = new TvdbSeriesDataBuilder()
+            .WithId(100)
+            .WithName("Katla")
+            .WithEpisodes(tvdbEp1)
+            .Build();
+        _tvdb.GetSeriesAsync(100, Arg.Any<CancellationToken>())
+            .Returns(series100);
+        _tvdb.GetEpisodeTranslationAsync(10, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new EpisodeTranslation("Eldur", "", "isl", false));
+
+        Episode tvdbEp2 = new TvdbEpisodeDataBuilder()
+            .WithId(20)
+            .WithName("Unrelated")
+            .WithNameTranslations("isl")
+            .WithSeasonNumber(1)
+            .WithNumber(1)
+            .Build();
+        SeriesData series200 = new TvdbSeriesDataBuilder()
+            .WithId(200)
+            .WithName("Katla")
+            .WithEpisodes(tvdbEp2)
+            .Build();
+        _tvdb.GetSeriesAsync(200, Arg.Any<CancellationToken>())
+            .Returns(series200);
+        _tvdb.GetEpisodeTranslationAsync(20, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new EpisodeTranslation("Ótengdur", "", "isl", false));
+
+        _lookupQueue.Enqueue(1, program.Name);
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        program.Series.ShouldNotBeNull();
+        program.Series.TvdbId.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task ReturnsNull_WhenMultipleExactMatches_AndMultipleCandidatesMatchEpisodes()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Katla")
+            .WithForeignName(null)
+            .Build();
+        program.TryAddEpisode("ep1", new Uri("http://test.com"), "Eldur", "desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Datum match1 = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("100")
+            .Build();
+        Datum match2 = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("200")
+            .Build();
+
+        _tvdb.SearchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(CreateSearchResponse(match1, match2));
+
+        Episode tvdbEp1 = new TvdbEpisodeDataBuilder()
+            .WithId(10)
+            .WithName("Fire")
+            .WithNameTranslations("isl")
+            .WithSeasonNumber(1)
+            .WithNumber(1)
+            .Build();
+        SeriesData series100 = new TvdbSeriesDataBuilder()
+            .WithId(100)
+            .WithName("Katla")
+            .WithEpisodes(tvdbEp1)
+            .Build();
+        _tvdb.GetSeriesAsync(100, Arg.Any<CancellationToken>())
+            .Returns(series100);
+        _tvdb.GetEpisodeTranslationAsync(10, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new EpisodeTranslation("Eldur", "", "isl", false));
+
+        Episode tvdbEp2 = new TvdbEpisodeDataBuilder()
+            .WithId(20)
+            .WithName("Also Fire")
+            .WithNameTranslations("isl")
+            .WithSeasonNumber(1)
+            .WithNumber(1)
+            .Build();
+        SeriesData series200 = new TvdbSeriesDataBuilder()
+            .WithId(200)
+            .WithName("Katla")
+            .WithEpisodes(tvdbEp2)
+            .Build();
+        _tvdb.GetSeriesAsync(200, Arg.Any<CancellationToken>())
+            .Returns(series200);
+        _tvdb.GetEpisodeTranslationAsync(20, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new EpisodeTranslation("Eldur", "", "isl", false));
+
+        _lookupQueue.Enqueue(1, program.Name);
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        program.Series.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ReturnsNull_WhenMultipleExactMatches_AndNoTranslationsAvailable()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Katla")
+            .WithForeignName(null)
+            .Build();
+        program.TryAddEpisode("ep1", new Uri("http://test.com"), "Eldur", "desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Datum match1 = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("100")
+            .Build();
+        Datum match2 = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("200")
+            .Build();
+
+        _tvdb.SearchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(CreateSearchResponse(match1, match2));
+
+        SeriesData series100 = new TvdbSeriesDataBuilder()
+            .WithId(100)
+            .WithName("Katla")
+            .Build();
+        _tvdb.GetSeriesAsync(100, Arg.Any<CancellationToken>())
+            .Returns(series100);
+
+        SeriesData series200 = new TvdbSeriesDataBuilder()
+            .WithId(200)
+            .WithName("Katla")
+            .Build();
+        _tvdb.GetSeriesAsync(200, Arg.Any<CancellationToken>())
+            .Returns(series200);
+
+        _lookupQueue.Enqueue(1, program.Name);
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        program.Series.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SkipsDisambiguation_WhenMultipleExactMatches_AndProgramHasNoEpisodes()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Katla")
+            .WithForeignName(null)
+            .Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Datum match1 = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("100")
+            .Build();
+        Datum match2 = new DatumBuilder()
+            .WithName("Katla")
+            .WithTvdbId("200")
+            .Build();
+
+        _tvdb.SearchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(CreateSearchResponse(match1, match2));
+        _lookupQueue.Enqueue(1, program.Name);
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        program.Series.ShouldBeNull();
+        await _tvdb.DidNotReceive().GetSeriesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task FallsBackToForeignName_WhenIcelandicNameIsAmbiguous()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- When multiple exact TVDB series matches are found, disambiguate by fetching Icelandic episode translations for each candidate and comparing against the program's RUV episode names
- The candidate whose episode translations match wins; ties or no matches fall back to current behavior (return null)
- Threads `CancellationToken` through the disambiguation path and short-circuits translation fetching once a match is confirmed

## Test plan
- [x] Unit test: single candidate wins by translation match
- [x] Unit test: tie (both candidates match) returns null
- [x] Unit test: no translations available returns null
- [x] Unit test: no episodes on program skips disambiguation
- [x] All 602 tests pass (554 unit + 48 integration)

Closes #192