### PR TITLE
Add RuvEpisode ToString override and use it in logging

### DIFF
--- a/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
+++ b/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
@@ -65,7 +65,7 @@ internal class DownloadQueueProcessor(
             return;
         }
 
-        logger.LogInformation("Downloading {Program} - {Title}", item.Episode.Program.Name, item.Episode.Title);
+        logger.LogInformation("Downloading {Episode}", item.Episode.ToString());
         string tentativePath = item.Episode.ToFilePath(
             downloadsRootDirectory,
             episodeDownloadDirectory,
@@ -103,11 +103,8 @@ internal class DownloadQueueProcessor(
         if (missingEpisode is null)
         {
             logger.LogError(
-                "{Program} S{Season:D2}E{Episode:D2} {Title} was scheduled for manual import into Sonarr but was not found in missing episodes.",
-                item.Episode.Program.Name,
-                item.Episode.SeasonNumber,
-                item.Episode.EpisodeNumber,
-                item.Episode.Title);
+                "{Episode} was scheduled for manual import into Sonarr but was not found in missing episodes.",
+                item.Episode.ToString());
             return;
         }
 
@@ -122,11 +119,7 @@ internal class DownloadQueueProcessor(
             Languages: file.Languages,
             ReleaseGroup: "RUV");
 
-        logger.LogInformation("Importing {Program} S{Season:D2}E{Episode:D2} {Title} into Sonarr",
-            item.Episode.Program.Name,
-            item.Episode.SeasonNumber,
-            item.Episode.EpisodeNumber,
-            item.Episode.Title);
+        logger.LogInformation("Importing {Episode} into Sonarr", item.Episode.ToString());
         await sonarr.ManualImportFilesAsync([request]);
     }
 }

--- a/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
+++ b/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
@@ -78,24 +78,31 @@ internal sealed class RuvEpisodesSyncJob(
 
             logger.LogDebug("Adding episodes to RÚV program '{Name}'", program.Name);
 
-            ruvProgram.Episodes
-                .Where(e => program.TryAddEpisode(
+            foreach (RuvTvEpisode e in ruvProgram.Episodes)
+            {
+                bool added = program.TryAddEpisode(
                     id: e.Id,
                     uri: e.File,
                     title: e.Title,
                     description: e.Description.Count > 0 ? e.Description[0] : string.Empty,
                     firstRun: e.FirstRun,
-                    duration: TimeSpan.FromSeconds(e.Duration)))
-                .ToList()
-                .ForEach(e => logger.LogInformation("Added RÚV episode '{EpisodeName}' to program '{Name}'", e.Title, program.Name));
+                    duration: TimeSpan.FromSeconds(e.Duration));
+
+                if (added)
+                {
+                    RuvEpisode newEpisode = program.Episodes.First(ep => ep.RuvId == e.Id);
+                    logger.LogInformation("Added RÚV episode {Episode}", newEpisode.ToString());
+                }
+            }
 
             logger.LogDebug("Removing episodes from RÚV program '{Name}'", program.Name);
-            IEnumerable<RuvEpisode> removed = program.Episodes
-                .Where(entity => !ruvProgram.Episodes.Select(episodeDto => episodeDto.Id).Contains(entity.RuvId));
+            List<RuvEpisode> removed = program.Episodes
+                .Where(entity => !ruvProgram.Episodes.Select(episodeDto => episodeDto.Id).Contains(entity.RuvId))
+                .ToList();
 
             foreach (RuvEpisode episode in removed)
             {
-                logger.LogInformation("Removed RÚV episode '{EpisodeName}' from program '{Name}'", episode.Title, program.Name);
+                logger.LogInformation("Removed RÚV episode {Episode}", episode.ToString());
                 program.RemoveEpisode(episode);
             }
 

--- a/src/Ruvarr/Programs/Commands/MatchEpisode/MatchEpisodeHandler.cs
+++ b/src/Ruvarr/Programs/Commands/MatchEpisode/MatchEpisodeHandler.cs
@@ -45,11 +45,8 @@ internal sealed class MatchEpisodeHandler(
         await dbContext.SaveChangesAsync(cancellationToken);
 
         logger.LogInformation(
-            "Matched RÚV episode {Program} - {Title} with TVDB S{Season:D2}E{Number:D2} - {Name}",
-            episode.Program.Name,
-            episode.Title,
-            tvdbEpisode.SeasonNumber,
-            tvdbEpisode.Number,
+            "Matched RÚV episode {Episode} with TVDB episode {TvdbEpisodeName}",
+            episode.ToString(),
             tvdbEpisode.Name);
 
         return RuvarrResult.Success;

--- a/src/Ruvarr/Programs/Commands/MatchProgramEpisodes/MatchProgramEpisodesHandler.cs
+++ b/src/Ruvarr/Programs/Commands/MatchProgramEpisodes/MatchProgramEpisodesHandler.cs
@@ -70,15 +70,12 @@ internal sealed class MatchProgramEpisodesHandler(
                 return ProgramErrors.EpisodeNotFound;
             }
 
-            logger.LogInformation(
-                "Matched RÚV episode '{RuvEpisode}' of program '{ProgramName}' with TVDB episode '{SeriesName}' S{Season:D2}E{Episode:D2} '{EpisodeName}'",
-                episode.Title,
-                program.Name,
-                series.Series.Name,
-                tvdbEpisode.SeasonNumber,
-                tvdbEpisode.Number,
-                tvdbEpisode.Name);
             episode.Match(tvdbEpisode.Id, tvdbEpisode.SeasonNumber, tvdbEpisode.Number, missingTvdbIds.Contains(tvdbEpisode.Id));
+            logger.LogInformation(
+                "Matched RÚV episode {Episode} with TVDB episode '{TvdbSeries}' - '{TvdbEpisodeName}'",
+                episode.ToString(),
+                series.Series.Name,
+                tvdbEpisode.Name);
         }
 
         await dbcontext.SaveChangesAsync(cancellationToken);

--- a/src/Ruvarr/Programs/Domain/RuvEpisode.cs
+++ b/src/Ruvarr/Programs/Domain/RuvEpisode.cs
@@ -72,6 +72,16 @@ internal sealed partial class RuvEpisode
         };
     }
 
+    public override string ToString()
+    {
+        if (SeasonNumber is not null && EpisodeNumber is not null)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0} S{1:D2}E{2:D2} - {3}", Program.Name, SeasonNumber, EpisodeNumber, Title);
+        }
+
+        return $"{Program.Name} - {Title}";
+    }
+
     public string ToFilename()
     {
         StringBuilder builder = new();

--- a/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
+++ b/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
@@ -46,7 +46,7 @@ internal sealed class TvdbEpisodeLookupJob(
         {
             logger.LogDebug("No RÚV program pending TVDB episode lookup");
             lookupQueue.MarkComplete(ruvId);
-        broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
+            broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
             return;
         }
 
@@ -57,7 +57,7 @@ internal sealed class TvdbEpisodeLookupJob(
         {
             await ScheduleLookupAsync(program);
             lookupQueue.MarkComplete(ruvId);
-        broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
+            broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
             return;
         }
 
@@ -117,15 +117,12 @@ internal sealed class TvdbEpisodeLookupJob(
 
             RuvEpisode episode = episodes[0];
 
-            logger.LogInformation(
-                "Matched RÚV episode '{RuvEpisode}' of program '{ProgramName}' with TVDB episode '{SeriesName}' S{Season:D2}E{Episode:D2} '{EpisodeName}'",
-                episode.Title,
-                program.Name,
-                seriesData.Series.Name,
-                translatedEpisode.SeasonNumber,
-                translatedEpisode.Number,
-                translatedEpisode.Name);
             episode.Match(translatedEpisode.Id, translatedEpisode.SeasonNumber, translatedEpisode.Number, missingTvdbIds.Contains(translatedEpisode.Id));
+            logger.LogInformation(
+                "Matched RÚV episode {Episode} with TVDB episode '{TvdbSeries}' - '{TvdbEpisodeName}'",
+                episode.ToString(),
+                seriesData.Series.Name,
+                translatedEpisode.Name);
         }
     }
 
@@ -157,15 +154,14 @@ internal sealed class TvdbEpisodeLookupJob(
                             continue;
                         }
 
+                        unmatchedEpisode.Match(tvdbEpisode.Id, tvdbEpisode.SeasonNumber, tvdbEpisode.Number, missingTvdbIds.Contains(tvdbEpisode.Id));
                         logger.LogInformation(
-                            "Matched RÚV episode '{RuvEpisode}' of program '{ProgramName}' with TVDB episode '{SeriesName}' S{Season:D2}E{Episode:D2} '{EpisodeName}' via season/episode fallback",
-                            unmatchedEpisode.Title,
-                            program.Name,
+                            "Matched RÚV episode {Episode} with TVDB episode '{TvdbSeries}' S{TvdbSeason:D2}E{TvdbEpisode:D2} '{TvdbEpisodeName}' via season/episode fallback",
+                            unmatchedEpisode.ToString(),
                             seriesData.Series.Name,
                             tvdbEpisode.SeasonNumber,
                             tvdbEpisode.Number,
                             tvdbEpisode.Name);
-                        unmatchedEpisode.Match(tvdbEpisode.Id, tvdbEpisode.SeasonNumber, tvdbEpisode.Number, missingTvdbIds.Contains(tvdbEpisode.Id));
                     }
                 }
             }
@@ -214,15 +210,14 @@ internal sealed class TvdbEpisodeLookupJob(
                 continue;
             }
 
+            partTwoEpisode.Match(tvdbPartTwoEpisode.Id, tvdbPartTwoEpisode.SeasonNumber, tvdbPartTwoEpisode.Number, missingTvdbIds.Contains(tvdbPartTwoEpisode.Id));
             logger.LogInformation(
-                "Matched RÚV episode '{RuvEpisode}' of program '{ProgramName}' with TVDB episode '{SeriesName}' S{Season:D2}E{Episode:D2} '{EpisodeName}' via part-one sibling fallback",
-                partTwoEpisode.Title,
-                program.Name,
+                "Matched RÚV episode {Episode} with TVDB episode '{TvdbSeries}' S{TvdbSeason:D2}E{TvdbEpisode:D2} '{TvdbEpisodeName}' via part-one sibling fallback",
+                partTwoEpisode.ToString(),
                 seriesData.Series.Name,
                 tvdbPartTwoEpisode.SeasonNumber,
                 tvdbPartTwoEpisode.Number,
                 tvdbPartTwoEpisode.Name);
-            partTwoEpisode.Match(tvdbPartTwoEpisode.Id, tvdbPartTwoEpisode.SeasonNumber, tvdbPartTwoEpisode.Number, missingTvdbIds.Contains(tvdbPartTwoEpisode.Id));
         }
     }
 

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/ToString.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvEpisodeTests/ToString.cs
@@ -1,0 +1,68 @@
+using Ruvarr.Programs.Domain;
+using Ruvarr.Testing.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.Domain.RuvEpisodeTests;
+
+public sealed class ToString
+{
+    [Fact]
+    public void ReturnsProgramNameAndTitle_WhenEpisodeIsNotMatched()
+    {
+        // Arrange
+        RuvProgram program = new RuvProgramBuilder()
+            .WithName("Krakkar")
+            .Build();
+        RuvEpisode sut = new RuvEpisodeBuilder()
+            .WithProgram(program)
+            .WithTitle("Fyrsti dagurinn")
+            .Build();
+
+        // Act
+        string? result = sut.ToString();
+
+        // Assert
+        result.ShouldBe("Krakkar - Fyrsti dagurinn");
+    }
+
+    [Fact]
+    public void ReturnsProgramNameSeasonEpisodeAndTitle_WhenEpisodeIsMatched()
+    {
+        // Arrange
+        RuvProgram program = new RuvProgramBuilder()
+            .WithName("Krakkar")
+            .Build();
+        RuvEpisode sut = new RuvEpisodeBuilder()
+            .WithProgram(program)
+            .WithTitle("Fyrsti dagurinn")
+            .Build();
+        sut.Match(tvdbId: 1234, season: 1, episode: 3, isMissing: false);
+
+        // Act
+        string? result = sut.ToString();
+
+        // Assert
+        result.ShouldBe("Krakkar S01E03 - Fyrsti dagurinn");
+    }
+
+    [Fact]
+    public void FormatsHighSeasonAndEpisodeNumbers_WithD2Formatting()
+    {
+        // Arrange
+        RuvProgram program = new RuvProgramBuilder()
+            .WithName("Krakkar")
+            .Build();
+        RuvEpisode sut = new RuvEpisodeBuilder()
+            .WithProgram(program)
+            .WithTitle("Fyrsti dagurinn")
+            .Build();
+        sut.Match(tvdbId: 5678, season: 12, episode: 145, isMissing: false);
+
+        // Act
+        string? result = sut.ToString();
+
+        // Assert
+        result.ShouldBe("Krakkar S12E145 - Fyrsti dagurinn");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ToString()` override to `RuvEpisode` that formats as `"{ProgramName} S{Season:D2}E{Episode:D2} - {Title}"` (matched) or `"{ProgramName} - {Title}"` (unmatched)
- Refactor all episode log statements across 5 files to use the new override
- Fix collection-modified-during-enumeration bug in `RuvEpisodesSyncJob` by materializing the removed episodes query before iterating
- Fix indentation issues in `TvdbEpisodeLookupJob`

## Test plan
- [x] 3 new unit tests for `ToString()` (unmatched, matched, high season/episode numbers)
- [x] All 605 tests pass (557 unit + 48 integration)
- [x] Build passes with 0 warnings

Closes #197