### PR TITLE
Refresh program details live when matched

### DIFF
--- a/src/Ruvarr/Programs/Events/ProgramMatchedTvdbEventHandler.cs
+++ b/src/Ruvarr/Programs/Events/ProgramMatchedTvdbEventHandler.cs
@@ -12,6 +12,7 @@ internal sealed class ProgramMatchedTvdbEventHandler(
     {
         notifier.Enqueue(@event.RuvId, @event.Name);
         broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
+        broadcaster.Publish(@event);
         return Task.CompletedTask;
     }
 }

--- a/src/Ruvarr/Programs/ProgramDetail.razor
+++ b/src/Ruvarr/Programs/ProgramDetail.razor
@@ -39,7 +39,7 @@ else
     <div class="program-header">
         @if (_program.ImageUrl is not null)
         {
-            <img class="program-thumbnail" src="@_program.ImageUrl" alt="@_program.ProgramName" width="288" height="400" decoding="async" />
+            <img @key="@_program.ImageUrl" class="program-thumbnail" src="@_program.ImageUrl" alt="@_program.ProgramName" width="288" height="400" decoding="async" />
         }
         <div class="program-header-content">
         <div class="program-header-meta">
@@ -249,12 +249,14 @@ else
     private MatchEpisodeDialog? _matchDialog;
     private AddToSonarrDialog? _addToSonarrDialog;
     private DateTime _lastEpisodeReloadTime;
+    private DateTime _lastProgramReloadTime;
 
     protected override async Task OnInitializedAsync()
     {
         _ = WatchDownloadQueueAsync();
         _ = WatchRefreshQueueAsync();
         _ = WatchEpisodeMatchesAsync();
+        _ = WatchProgramMatchesAsync();
 
         await using AsyncServiceScope scope = ScopeFactory.CreateAsyncScope();
         IRequestHandler<GetProgramQuery, ProgramSummary?> programHandler =
@@ -327,6 +329,72 @@ else
             _lastEpisodeReloadTime = DateTime.UtcNow;
             await ReloadEpisodesAsync();
         }
+    }
+
+    private async Task WatchProgramMatchesAsync()
+    {
+        Task tvdbTask = Task.Run(async () =>
+        {
+            await foreach (ProgramMatchedTvdbEvent @event in Broadcaster.Subscribe<ProgramMatchedTvdbEvent>(_cts.Token))
+            {
+                if (@event.RuvId != RuvId)
+                {
+                    continue;
+                }
+
+                if (DateTime.UtcNow - _lastProgramReloadTime < TimeSpan.FromMilliseconds(200))
+                {
+                    continue;
+                }
+
+                await Task.Delay(200, _cts.Token);
+
+                if (DateTime.UtcNow - _lastProgramReloadTime < TimeSpan.FromMilliseconds(200))
+                {
+                    continue;
+                }
+
+                _lastProgramReloadTime = DateTime.UtcNow;
+                await ReloadProgramDetailsAsync();
+            }
+        }, _cts.Token);
+
+        Task tmdbTask = Task.Run(async () =>
+        {
+            await foreach (ProgramMatchedTmdbEvent @event in Broadcaster.Subscribe<ProgramMatchedTmdbEvent>(_cts.Token))
+            {
+                if (@event.RuvId != RuvId)
+                {
+                    continue;
+                }
+
+                if (DateTime.UtcNow - _lastProgramReloadTime < TimeSpan.FromMilliseconds(200))
+                {
+                    continue;
+                }
+
+                await Task.Delay(200, _cts.Token);
+
+                if (DateTime.UtcNow - _lastProgramReloadTime < TimeSpan.FromMilliseconds(200))
+                {
+                    continue;
+                }
+
+                _lastProgramReloadTime = DateTime.UtcNow;
+                await ReloadProgramDetailsAsync();
+            }
+        }, _cts.Token);
+
+        await Task.WhenAll(tvdbTask, tmdbTask);
+    }
+
+    private async Task ReloadProgramDetailsAsync()
+    {
+        await using AsyncServiceScope scope = ScopeFactory.CreateAsyncScope();
+        IRequestHandler<GetProgramQuery, ProgramSummary?> handler =
+            scope.ServiceProvider.GetRequiredService<IRequestHandler<GetProgramQuery, ProgramSummary?>>();
+        _program = await handler.Handle(new GetProgramQuery(RuvId), _cts.Token);
+        await InvokeAsync(StateHasChanged);
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/Ruvarr.UnitTests/Programs/ProgramMatchedTvdbEventHandlerTests/Handle.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramMatchedTvdbEventHandlerTests/Handle.cs
@@ -28,6 +28,38 @@ public sealed class Handle
     }
 
     [Fact]
+    public async Task BroadcastsProgramMatchedTvdbEvent()
+    {
+        // Arrange
+        TvdbEpisodeLookupNotifier notifier = new();
+        DomainEventBroadcaster broadcaster = new();
+        ProgramMatchedTvdbEventHandler sut = new(notifier, broadcaster);
+        ProgramMatchedTvdbEvent @event = new(42, "Test Program");
+
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+        ProgramMatchedTvdbEvent? received = null;
+        IAsyncEnumerable<ProgramMatchedTvdbEvent> subscription =
+            broadcaster.Subscribe<ProgramMatchedTvdbEvent>(cts.Token);
+        Task watchTask = Task.Run(async () =>
+        {
+            await foreach (ProgramMatchedTvdbEvent e in subscription)
+            {
+                received = e;
+                await cts.CancelAsync();
+            }
+        }, cts.Token);
+
+        // Act
+        await sut.Handle(@event, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Task.WhenAny(watchTask, Task.Delay(2000, TestContext.Current.CancellationToken));
+        received.ShouldNotBeNull();
+        received.RuvId.ShouldBe(42);
+        received.Name.ShouldBe("Test Program");
+    }
+
+    [Fact]
     public async Task PublishesQueueChangedEvent()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Subscribe to `ProgramMatchedTvdbEvent` and `ProgramMatchedTmdbEvent` in `ProgramDetail.razor` to reload program details automatically when a program is matched
- Broadcast `ProgramMatchedTvdbEvent` from `ProgramMatchedTvdbEventHandler` (TMDB handler already did this)
- Use `@key` on the `<img>` element to prevent unnecessary image reloads when the URL hasn't changed
- 200ms debounce to prevent rapid successive reloads

## Test plan
- [x] Added `BroadcastsProgramMatchedTvdbEvent` unit test
- [x] All 606 tests pass
- [ ] Manually verify program header updates live when matched via TVDB lookup job
- [ ] Manually verify image does not flash/reload when URL is unchanged

Closes #195