### PR TITLE
Fix stuck Processing items in TVDB lookup jobs

### DIFF
--- a/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
+++ b/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
@@ -37,42 +37,50 @@ internal sealed class TvdbEpisodeLookupJob(
         lookupQueue.MarkProcessing(ruvId);
         broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
 
-        RuvProgram? program = await dbContext.Set<RuvProgram>()
-            .Include(x => x.Series)
-            .Include(x => x.Episodes)
-                .ThenInclude(x => x.TvdbEpisodes)
-            .Where(x => x.RuvId == ruvId)
-            .FirstOrDefaultAsync();
-
-        if (program is null || program.Series is null)
+        try
         {
-            logger.LogDebug("No RÚV program pending TVDB episode lookup");
-            lookupQueue.MarkComplete(ruvId);
-            broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
-            return;
-        }
+            RuvProgram? program = await dbContext.Set<RuvProgram>()
+                .Include(x => x.Series)
+                .Include(x => x.Episodes)
+                    .ThenInclude(x => x.TvdbEpisodes)
+                .Where(x => x.RuvId == ruvId)
+                .FirstOrDefaultAsync();
 
-        logger.LogDebug("Getting TVDB series data");
-        SeriesData? seriesData = await tvdb.GetSeriesAsync(program.Series.TvdbId);
+            if (program is null || program.Series is null)
+            {
+                logger.LogDebug("No RÚV program pending TVDB episode lookup");
+                return;
+            }
 
-        if (seriesData is null)
-        {
+            logger.LogDebug("Getting TVDB series data");
+            SeriesData? seriesData = await tvdb.GetSeriesAsync(program.Series.TvdbId);
+
+            if (seriesData is null)
+            {
+                await ScheduleLookupAsync(program);
+                return;
+            }
+
+            IReadOnlyCollection<MissingEpisode> missingEpisodes = await sonarr.GetMissingEpisodesAsync();
+            HashSet<int> missingTvdbIds = [.. missingEpisodes.Select(x => x.TvdbId)];
+
+            await MatchByTranslationAsync(program, seriesData, missingTvdbIds);
+            MatchByEpisodeNumber(program, seriesData, missingTvdbIds);
+            MatchByPartOneSibling(program, seriesData, missingTvdbIds);
+
             await ScheduleLookupAsync(program);
+        }
+#pragma warning disable CA1031 // Catch all exceptions to prevent queue items from getting stuck in Processing state
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            logger.LogError(ex, "Error during TVDB episode lookup for RuvId {RuvId}", ruvId);
+        }
+        finally
+        {
             lookupQueue.MarkComplete(ruvId);
             broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
-            return;
         }
-
-        IReadOnlyCollection<MissingEpisode> missingEpisodes = await sonarr.GetMissingEpisodesAsync();
-        HashSet<int> missingTvdbIds = [.. missingEpisodes.Select(x => x.TvdbId)];
-
-        await MatchByTranslationAsync(program, seriesData, missingTvdbIds);
-        MatchByEpisodeNumber(program, seriesData, missingTvdbIds);
-        MatchByPartOneSibling(program, seriesData, missingTvdbIds);
-
-        await ScheduleLookupAsync(program);
-        lookupQueue.MarkComplete(ruvId);
-        broadcaster.Publish(new QueueChangedEvent<TvdbEpisodeLookupQueueItemSummary>());
     }
 
     private async Task MatchByTranslationAsync(RuvProgram program, SeriesData seriesData, HashSet<int> missingTvdbIds)

--- a/src/Ruvarr/TvdbSeriesLookup/Jobs/TvdbSeriesLookupJob.cs
+++ b/src/Ruvarr/TvdbSeriesLookup/Jobs/TvdbSeriesLookupJob.cs
@@ -35,84 +35,85 @@ internal sealed class TvdbSeriesLookupJob(
         lookupQueue.MarkProcessing(ruvId);
         broadcaster.Publish(new QueueChangedEvent<TvdbSeriesLookupQueueItemSummary>());
 
-        RuvProgram? program = await dbContext.Set<RuvProgram>()
-            .Include(x => x.Series)
-            .Include(x => x.Episodes)
-            .Where(x => x.RuvId == ruvId)
-            .FirstOrDefaultAsync();
-
-        if (program is null)
+        try
         {
-            logger.LogDebug("No RÚV program pending TVDB series lookup");
-            lookupQueue.MarkComplete(ruvId);
-            broadcaster.Publish(new QueueChangedEvent<TvdbSeriesLookupQueueItemSummary>());
-            return;
-        }
+            RuvProgram? program = await dbContext.Set<RuvProgram>()
+                .Include(x => x.Series)
+                .Include(x => x.Episodes)
+                .Where(x => x.RuvId == ruvId)
+                .FirstOrDefaultAsync();
 
-        if (program.Series is not null)
-        {
-            SeriesData? seriesData = await tvdb.GetSeriesAsync(program.Series.TvdbId, cancellationToken: context.CancellationToken);
-
-            if (seriesData is null)
+            if (program is null)
             {
-                logger.LogWarning("TVDB returned no series data for TvdbId '{TvdbId}'", program.Series.TvdbId);
-                lookupQueue.MarkComplete(ruvId);
-            broadcaster.Publish(new QueueChangedEvent<TvdbSeriesLookupQueueItemSummary>());
+                logger.LogDebug("No RÚV program pending TVDB series lookup");
                 return;
             }
 
-            program.Series.UpdateSlug(seriesData.Series.Slug);
+            if (program.Series is not null)
+            {
+                SeriesData? seriesData = await tvdb.GetSeriesAsync(program.Series.TvdbId, cancellationToken: context.CancellationToken);
+
+                if (seriesData is null)
+                {
+                    logger.LogWarning("TVDB returned no series data for TvdbId '{TvdbId}'", program.Series.TvdbId);
+                    return;
+                }
+
+                program.Series.UpdateSlug(seriesData.Series.Slug);
+
+                await dbContext.SaveChangesAsync(context.CancellationToken);
+
+                return;
+            }
+
+            IReadOnlyList<RuvEpisode> episodes = program.Episodes;
+
+            CancellationToken cancellationToken = context.CancellationToken;
+
+            Datum? match = await SearchTvdbAsync(program.Name, checkTranslations: true, episodes: episodes, cancellationToken)
+                ?? await TryRemovingNumeralEnding(program.Name, checkTranslations: true, episodes: episodes, cancellationToken)
+                ?? await SearchTvdbAsync(program.ForeignName, checkTranslations: false, episodes: episodes, cancellationToken)
+                ?? await TryRemovingNumeralEnding(program.ForeignName, checkTranslations: false, episodes: episodes, cancellationToken);
+
+            if (match is null)
+            {
+                await ScheduleLookupAsync(program, context.CancellationToken);
+                return;
+            }
+
+            if (!int.TryParse(match.TvdbId, NumberStyles.Integer, CultureInfo.InvariantCulture, out int matchTvdbId) || matchTvdbId < 1)
+            {
+                logger.LogWarning("Could not parse TvdbId '{TvdbId}' as integer for TVDB match '{Name}'", match.TvdbId, match.Name);
+                program.ScheduleLookup();
+                await dbContext.SaveChangesAsync(context.CancellationToken);
+                return;
+            }
+
+            TvdbSeries? entity = await dbContext
+                .Set<TvdbSeries>()
+                .Where(x => x.TvdbId == matchTvdbId)
+                .FirstOrDefaultAsync()
+                ?? TvdbSeries.Create(matchTvdbId, match.Name, match.Slug);
+
+            entity.UpdateSlug(match.Slug);
+
+            program.MatchTvdb(entity);
 
             await dbContext.SaveChangesAsync(context.CancellationToken);
 
-            lookupQueue.MarkComplete(ruvId);
-            broadcaster.Publish(new QueueChangedEvent<TvdbSeriesLookupQueueItemSummary>());
-            return;
+            logger.LogInformation("Matched RÚV program '{Program}' with TVDB series '{Series}'", program.Name, entity.Name);
         }
-
-        IReadOnlyList<RuvEpisode> episodes = program.Episodes;
-
-        CancellationToken cancellationToken = context.CancellationToken;
-
-        Datum? match = await SearchTvdbAsync(program.Name, checkTranslations: true, episodes: episodes, cancellationToken)
-            ?? await TryRemovingNumeralEnding(program.Name, checkTranslations: true, episodes: episodes, cancellationToken)
-            ?? await SearchTvdbAsync(program.ForeignName, checkTranslations: false, episodes: episodes, cancellationToken)
-            ?? await TryRemovingNumeralEnding(program.ForeignName, checkTranslations: false, episodes: episodes, cancellationToken);
-
-        if (match is null)
+#pragma warning disable CA1031 // Catch all exceptions to prevent queue items from getting stuck in Processing state
+        catch (Exception ex)
+#pragma warning restore CA1031
         {
-            await ScheduleLookupAsync(program, context.CancellationToken);
-            lookupQueue.MarkComplete(ruvId);
-            broadcaster.Publish(new QueueChangedEvent<TvdbSeriesLookupQueueItemSummary>());
-            return;
+            logger.LogError(ex, "Error during TVDB series lookup for RuvId {RuvId}", ruvId);
         }
-
-        if (!int.TryParse(match.TvdbId, NumberStyles.Integer, CultureInfo.InvariantCulture, out int matchTvdbId) || matchTvdbId < 1)
+        finally
         {
-            logger.LogWarning("Could not parse TvdbId '{TvdbId}' as integer for TVDB match '{Name}'", match.TvdbId, match.Name);
-            program.ScheduleLookup();
-            await dbContext.SaveChangesAsync(context.CancellationToken);
             lookupQueue.MarkComplete(ruvId);
             broadcaster.Publish(new QueueChangedEvent<TvdbSeriesLookupQueueItemSummary>());
-            return;
         }
-
-        TvdbSeries? entity = await dbContext
-            .Set<TvdbSeries>()
-            .Where(x => x.TvdbId == matchTvdbId)
-            .FirstOrDefaultAsync()
-            ?? TvdbSeries.Create(matchTvdbId, match.Name, match.Slug);
-
-        entity.UpdateSlug(match.Slug);
-
-        program.MatchTvdb(entity);
-
-        await dbContext.SaveChangesAsync(context.CancellationToken);
-
-        lookupQueue.MarkComplete(ruvId);
-        broadcaster.Publish(new QueueChangedEvent<TvdbSeriesLookupQueueItemSummary>());
-
-        logger.LogInformation("Matched RÚV program '{Program}' with TVDB series '{Series}'", program.Name, entity.Name);
     }
 
     private async Task ScheduleLookupAsync(RuvProgram program, CancellationToken cancellationToken)

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/ExceptionHandling.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbEpisodeLookupJobTests/ExceptionHandling.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Infrastructure.Sonarr;
+using Ruvarr.Infrastructure.Tvdb;
+using Ruvarr.Programs.Domain;
+using Ruvarr.Testing.Builders;
+using Ruvarr.TvdbEpisodeLookup.Jobs;
+using Ruvarr.TvdbEpisodeLookup.Notifiers;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Jobs.TvdbEpisodeLookupJobTests;
+
+public sealed class ExceptionHandling
+{
+    private readonly ITvdbClient _tvdb = Substitute.For<ITvdbClient>();
+    private readonly ISonarrClient _sonarr = Substitute.For<ISonarrClient>();
+    private readonly TvdbEpisodeLookupNotifier _notifier = new();
+    private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
+
+    public ExceptionHandling()
+    {
+        _sonarr.GetMissingEpisodesAsync().Returns([]);
+        _serviceProvider.GetService(Arg.Any<Type>()).Returns(Array.Empty<object>());
+    }
+
+    private RuvarrDbContext CreateDbContext() => new(
+        new DbContextOptionsBuilder<RuvarrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options,
+        _serviceProvider);
+
+    private TvdbEpisodeLookupJob CreateJob(RuvarrDbContext dbContext) => new(
+        NullLogger<TvdbEpisodeLookupJob>.Instance,
+        dbContext, _tvdb, _sonarr, _notifier, new DomainEventBroadcaster());
+
+    [Fact]
+    public async Task MarksComplete_WhenTvdbClientThrows()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        TvdbSeries series = new TvdbSeriesBuilder().WithId(1000).Build();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).Build();
+        program.TryAddEpisode("ep0001", new Uri("http://test.com"), "Episode 1", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.MatchTvdb(series);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _tvdb.GetSeriesAsync(1000, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("TVDB API unavailable"));
+        _notifier.Enqueue(1, program.Name);
+        _notifier.Items.ShouldHaveSingleItem();
+        TvdbEpisodeLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        _notifier.Items.ShouldBeEmpty();
+    }
+}

--- a/tests/Ruvarr.UnitTests/Jobs/TvdbSeriesLookupJobTests/ExceptionHandling.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/TvdbSeriesLookupJobTests/ExceptionHandling.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+using Quartz;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Infrastructure.Tvdb;
+using Ruvarr.Programs.Domain;
+using Ruvarr.Testing.Builders;
+using Ruvarr.TvdbSeriesLookup.Jobs;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Jobs.TvdbSeriesLookupJobTests;
+
+public sealed class ExceptionHandling
+{
+    private readonly ITvdbClient _tvdb = Substitute.For<ITvdbClient>();
+    private readonly TvdbSeriesLookupNotifier _lookupQueue = new();
+    private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
+    private readonly IJobExecutionContext _context = Substitute.For<IJobExecutionContext>();
+
+    public ExceptionHandling()
+    {
+        _serviceProvider.GetService(Arg.Any<Type>()).Returns(Array.Empty<object>());
+        _context.CancellationToken.Returns(CancellationToken.None);
+    }
+
+    private RuvarrDbContext CreateDbContext() => new(
+        new DbContextOptionsBuilder<RuvarrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options,
+        _serviceProvider);
+
+    private TvdbSeriesLookupJob CreateJob(RuvarrDbContext dbContext) => new(
+        NullLogger<TvdbSeriesLookupJob>.Instance,
+        dbContext,
+        _tvdb,
+        _lookupQueue,
+        new DomainEventBroadcaster());
+
+    [Fact]
+    public async Task MarksComplete_WhenTvdbClientThrows()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(1)
+            .WithName("Test Program")
+            .WithForeignName(null)
+            .Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _tvdb.SearchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("TVDB API unavailable"));
+        _lookupQueue.Enqueue(1, program.Name);
+        _lookupQueue.Items.ShouldHaveSingleItem();
+        TvdbSeriesLookupJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        _lookupQueue.Items.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Wrap `TvdbSeriesLookupJob` and `TvdbEpisodeLookupJob` in try/catch/finally so `MarkComplete` and `QueueChangedEvent` publish always run, even when the TVDB client throws
- Prevents items from getting permanently stuck in Processing state in the in-memory queue
- Exceptions are caught and logged at Error level instead of propagating to Quartz

## Test plan

- [x] New `ExceptionHandling` tests for both jobs verify `MarkComplete` is called when TVDB client throws
- [x] All 627 tests pass (581 unit + 46 integration)
- [x] Zero build warnings

Closes #244