### PR TITLE
Add settings readiness check to RuvarrSettings

### DIFF
--- a/src/Ruvarr/Settings/RuvarrSettings.cs
+++ b/src/Ruvarr/Settings/RuvarrSettings.cs
@@ -11,5 +11,13 @@ internal sealed record RuvarrSettings(
 {
     public IReadOnlyList<string> IgnoredChannels { get; init; } = [];
 
+    public bool IsTvdbConfigured => !string.IsNullOrWhiteSpace(TvdbApiKey);
+
+    public bool IsTmdbConfigured => !string.IsNullOrWhiteSpace(TmdbApiKey);
+
+    public bool IsSonarrConfigured => !string.IsNullOrWhiteSpace(SonarrBaseAddress) && !string.IsNullOrWhiteSpace(SonarrApiKey);
+
+    public bool IsDownloadsConfigured => !string.IsNullOrWhiteSpace(DownloadsRootDirectory);
+
     public static RuvarrSettings Empty => new();
 }

--- a/tests/Ruvarr.UnitTests/Settings/RuvarrSettingsTests/ReadinessProperties.cs
+++ b/tests/Ruvarr.UnitTests/Settings/RuvarrSettingsTests/ReadinessProperties.cs
@@ -1,0 +1,190 @@
+using Ruvarr.Settings;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Settings.RuvarrSettingsTests;
+
+public sealed class ReadinessProperties
+{
+    [Fact]
+    public void IsTvdbConfigured_ReturnsFalse_WhenTvdbApiKeyIsEmpty()
+    {
+        // Arrange
+        RuvarrSettings settings = new(TvdbApiKey: "");
+
+        // Act
+        bool result = settings.IsTvdbConfigured;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsTvdbConfigured_ReturnsFalse_WhenTvdbApiKeyIsWhitespace()
+    {
+        // Arrange
+        RuvarrSettings settings = new(TvdbApiKey: "  ");
+
+        // Act
+        bool result = settings.IsTvdbConfigured;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsTvdbConfigured_ReturnsTrue_WhenTvdbApiKeyIsSet()
+    {
+        // Arrange
+        RuvarrSettings settings = new(TvdbApiKey: "some-key");
+
+        // Act
+        bool result = settings.IsTvdbConfigured;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsTmdbConfigured_ReturnsFalse_WhenTmdbApiKeyIsEmpty()
+    {
+        // Arrange
+        RuvarrSettings settings = new(TmdbApiKey: "");
+
+        // Act
+        bool result = settings.IsTmdbConfigured;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsTmdbConfigured_ReturnsFalse_WhenTmdbApiKeyIsWhitespace()
+    {
+        // Arrange
+        RuvarrSettings settings = new(TmdbApiKey: "  ");
+
+        // Act
+        bool result = settings.IsTmdbConfigured;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsTmdbConfigured_ReturnsTrue_WhenTmdbApiKeyIsSet()
+    {
+        // Arrange
+        RuvarrSettings settings = new(TmdbApiKey: "some-key");
+
+        // Act
+        bool result = settings.IsTmdbConfigured;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsSonarrConfigured_ReturnsFalse_WhenBothEmpty()
+    {
+        // Arrange
+        RuvarrSettings settings = new(SonarrBaseAddress: "", SonarrApiKey: "");
+
+        // Act
+        bool result = settings.IsSonarrConfigured;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsSonarrConfigured_ReturnsFalse_WhenBaseAddressIsEmpty()
+    {
+        // Arrange
+        RuvarrSettings settings = new(SonarrBaseAddress: "", SonarrApiKey: "key");
+
+        // Act
+        bool result = settings.IsSonarrConfigured;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsSonarrConfigured_ReturnsFalse_WhenApiKeyIsEmpty()
+    {
+        // Arrange
+        RuvarrSettings settings = new(SonarrBaseAddress: "http://localhost:8989", SonarrApiKey: "");
+
+        // Act
+        bool result = settings.IsSonarrConfigured;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsSonarrConfigured_ReturnsFalse_WhenBaseAddressIsWhitespace()
+    {
+        // Arrange
+        RuvarrSettings settings = new(SonarrBaseAddress: "  ", SonarrApiKey: "key");
+
+        // Act
+        bool result = settings.IsSonarrConfigured;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsSonarrConfigured_ReturnsTrue_WhenBothSet()
+    {
+        // Arrange
+        RuvarrSettings settings = new(SonarrBaseAddress: "http://localhost:8989", SonarrApiKey: "key");
+
+        // Act
+        bool result = settings.IsSonarrConfigured;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsDownloadsConfigured_ReturnsFalse_WhenDownloadsRootDirectoryIsEmpty()
+    {
+        // Arrange
+        RuvarrSettings settings = new(DownloadsRootDirectory: "");
+
+        // Act
+        bool result = settings.IsDownloadsConfigured;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsDownloadsConfigured_ReturnsFalse_WhenDownloadsRootDirectoryIsWhitespace()
+    {
+        // Arrange
+        RuvarrSettings settings = new(DownloadsRootDirectory: "  ");
+
+        // Act
+        bool result = settings.IsDownloadsConfigured;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsDownloadsConfigured_ReturnsTrue_WhenDownloadsRootDirectoryIsSet()
+    {
+        // Arrange
+        RuvarrSettings settings = new(DownloadsRootDirectory: "/downloads");
+
+        // Act
+        bool result = settings.IsDownloadsConfigured;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Add computed boolean readiness properties to `RuvarrSettings`: `IsTvdbConfigured`, `IsTmdbConfigured`, `IsSonarrConfigured`, `IsDownloadsConfigured`
- Pure value checks (no network calls) enabling jobs and UI to gate on configuration status
- 14 unit tests covering all property combinations

Closes #246

## Test plan

- [x] All 641 tests pass (14 new readiness property tests)
- [x] `dotnet build` passes with zero warnings
- [x] Security review: no blocking findings
- [x] Performance review: no findings
- [x] Dependency audit: no vulnerable packages