### PR TITLE
Auto select next episode match

### DIFF
--- a/src/Ruvarr/Programs/MatchEpisodeDialog.razor
+++ b/src/Ruvarr/Programs/MatchEpisodeDialog.razor
@@ -227,12 +227,13 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1144", Justification = "Called from Razor template via @onclick")]
     private void AddEntry()
     {
-        int? previousSeason = _matchEntries.Count > 0 ? _matchEntries[^1].SelectedSeason : null;
+        MatchEntry? lastEntry = _matchEntries.Count > 0 ? _matchEntries[^1] : null;
         MatchEntry entry = new();
-        if (previousSeason is not null)
+        if (lastEntry?.SelectedSeason is not null)
         {
-            entry.SelectedSeason = previousSeason;
-            entry.SeasonEpisodes = [.. _allEpisodes.Where(e => e.SeasonNumber == previousSeason)];
+            entry.SelectedSeason = lastEntry.SelectedSeason;
+            entry.SeasonEpisodes = [.. _allEpisodes.Where(e => e.SeasonNumber == lastEntry.SelectedSeason)];
+            entry.SelectedEpisodeId = GetNextEpisodeId(entry.SeasonEpisodes, lastEntry.SelectedEpisodeId);
         }
         _matchEntries.Add(entry);
     }
@@ -271,6 +272,23 @@
         }
 
         return int.TryParse(parts[1], out number);
+    }
+
+    internal static int? GetNextEpisodeId(List<TvdbSeriesEpisode> seasonEpisodes, int? currentEpisodeId)
+    {
+        if (currentEpisodeId is null)
+        {
+            return null;
+        }
+
+        int currentIndex = seasonEpisodes.FindIndex(e => e.TvdbId == currentEpisodeId);
+
+        if (currentIndex < 0 || currentIndex >= seasonEpisodes.Count - 1)
+        {
+            return null;
+        }
+
+        return seasonEpisodes[currentIndex + 1].TvdbId;
     }
 
     internal static int? ResolveAutoSelectedSeason(List<EpisodeSummary> siblingEpisodes, List<int> availableSeasons)

--- a/tests/Ruvarr.UnitTests/Programs/MatchEpisodeDialogTests/GetNextEpisodeId.cs
+++ b/tests/Ruvarr.UnitTests/Programs/MatchEpisodeDialogTests/GetNextEpisodeId.cs
@@ -1,0 +1,78 @@
+using Ruvarr.Contracts;
+using Ruvarr.Programs;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.MatchEpisodeDialogTests;
+
+public sealed class GetNextEpisodeId
+{
+    [Fact]
+    public void ReturnsNextEpisodeWhenCurrentIsInTheMiddle()
+    {
+        // Arrange
+        List<TvdbSeriesEpisode> episodes =
+        [
+            new(100, "Episode 1", 1, 1),
+            new(101, "Episode 2", 1, 2),
+            new(102, "Episode 3", 1, 3),
+        ];
+
+        // Act
+        int? result = MatchEpisodeDialog.GetNextEpisodeId(episodes, currentEpisodeId: 101);
+
+        // Assert
+        result.ShouldBe(102);
+    }
+
+    [Fact]
+    public void ReturnsNullWhenCurrentIsLastEpisode()
+    {
+        // Arrange
+        List<TvdbSeriesEpisode> episodes =
+        [
+            new(100, "Episode 1", 1, 1),
+            new(101, "Episode 2", 1, 2),
+        ];
+
+        // Act
+        int? result = MatchEpisodeDialog.GetNextEpisodeId(episodes, currentEpisodeId: 101);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ReturnsNullWhenCurrentEpisodeIdIsNull()
+    {
+        // Arrange
+        List<TvdbSeriesEpisode> episodes =
+        [
+            new(100, "Episode 1", 1, 1),
+            new(101, "Episode 2", 1, 2),
+        ];
+
+        // Act
+        int? result = MatchEpisodeDialog.GetNextEpisodeId(episodes, currentEpisodeId: null);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ReturnsNullWhenCurrentEpisodeIdNotFoundInList()
+    {
+        // Arrange
+        List<TvdbSeriesEpisode> episodes =
+        [
+            new(100, "Episode 1", 1, 1),
+            new(101, "Episode 2", 1, 2),
+        ];
+
+        // Act
+        int? result = MatchEpisodeDialog.GetNextEpisodeId(episodes, currentEpisodeId: 999);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- Auto-select the next episode when adding a new match entry in the episode match dialog
- If episode 34 is selected, adding a new entry auto-selects episode 35, then 36, etc.
- Returns no selection when the current episode is the last in the season

Closes #236

## Test plan
- [x] Open match episode dialog, select an episode (e.g. episode 5), click "+ Add another match" — verify episode 6 is auto-selected
- [x] Repeat adding entries — verify each increments correctly
- [x] Select the last episode in a season, add another match — verify no episode is auto-selected (season is carried forward)
- [x] Add a match with no episode selected, add another — verify no episode is auto-selected
- [x] Run `dotnet test` — all 649 unit + 55 integration tests pass