### PR TITLE
Fix ResolveMatchingSeason to trust explicit season name

### DIFF
--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -195,13 +195,7 @@ internal sealed class RuvProgram
 
         if (SeasonNumber > 0)
         {
-            int namedSeasonCount = nonSpecials.Count(x => x.SeasonNumber == SeasonNumber);
-            bool otherSeasonSharesCount = nonSpecials
-                .Where(x => x.SeasonNumber != SeasonNumber)
-                .GroupBy(x => x.SeasonNumber)
-                .Any(g => g.Count() == namedSeasonCount);
-
-            return otherSeasonSharesCount ? 0 : SeasonNumber;
+            return SeasonNumber;
         }
 
         int matchingSeasonCount = nonSpecials

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/ResolveMatchingSeason.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/ResolveMatchingSeason.cs
@@ -82,7 +82,7 @@ public sealed class ResolveMatchingSeason
     }
 
     [Fact]
-    public void SeasonNumbered_AnotherSeasonSharesEpisodeCount_ReturnsZero()
+    public void SeasonNumbered_AnotherSeasonSharesEpisodeCount_ReturnsSeasonNumber()
     {
         // Arrange
         RuvProgram sut = new RuvProgramBuilder().WithName("Show II").Build();
@@ -95,7 +95,7 @@ public sealed class ResolveMatchingSeason
         int result = sut.ResolveMatchingSeason([s2e1, s4e1]);
 
         // Assert
-        result.ShouldBe(0);
+        result.ShouldBe(2);
     }
 
     [Fact]

--- a/tests/Ruvarr.UnitTests/TvdbEpisodeLookup/Strategies/EpisodeNumberMatchingStrategyTests.cs
+++ b/tests/Ruvarr.UnitTests/TvdbEpisodeLookup/Strategies/EpisodeNumberMatchingStrategyTests.cs
@@ -149,7 +149,7 @@ public sealed class EpisodeNumberMatchingStrategyTests
     }
 
     [Fact]
-    public async Task SkipsWhenOtherSeasonHasSameEpisodeCount()
+    public async Task MatchesWhenOtherSeasonSharesEpisodeCount()
     {
         // Arrange
         RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithName("Show II").Build();
@@ -168,6 +168,7 @@ public sealed class EpisodeNumberMatchingStrategyTests
         await sut.MatchAsync(context, CancellationToken.None);
 
         // Assert
-        program.Episodes[0].TvdbEpisodes.ShouldBeEmpty();
+        program.Episodes[0].TvdbEpisodes[0].TvdbId.ShouldBe(201);
+        program.Episodes[0].TvdbEpisodes[0].SeasonNumber.ShouldBe(2);
     }
 }


### PR DESCRIPTION
## Summary
- Removes the `otherSeasonSharesCount` episode-count guard from the `SeasonNumber > 0` branch of `ResolveMatchingSeason` — when the program name explicitly encodes a season number (e.g. "Molang IV"), that is sufficient evidence to resolve the season without further disambiguation
- Updates tests to reflect the correct behaviour: a named season is always resolved even when another TVDB season shares the same episode count

## Test plan
- [ ] `dotnet test --filter "FullyQualifiedName~ResolveMatchingSeason"` — all pass
- [ ] `dotnet test` — all 726 tests pass

Closes #284