### PR TITLE
Use ForeignName as fallback for season number detection

### DIFF
--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -61,25 +61,37 @@ internal sealed class RuvProgram
     {
         get
         {
-            if (string.IsNullOrWhiteSpace(Name))
+            int season = ParseSeasonFromSuffix(Name);
+
+            if (season > 0)
             {
-                return 0;
+                return season;
             }
 
-            string suffix = Name.Split(' ')[^1];
+            return ParseSeasonFromSuffix(ForeignName);
+        }
+    }
 
-            if (RomanNumeral.TryParse(suffix, out RomanNumeral? rn) && rn.Number > 0)
-            {
-                return rn.Number;
-            }
-
-            if (int.TryParse(suffix, out int n) && n > 0)
-            {
-                return n;
-            }
-
+    private static int ParseSeasonFromSuffix(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
             return 0;
         }
+
+        string suffix = name.Split(' ')[^1];
+
+        if (RomanNumeral.TryParse(suffix, out RomanNumeral? rn) && rn.Number > 0)
+        {
+            return rn.Number;
+        }
+
+        if (int.TryParse(suffix, out int n) && n > 0)
+        {
+            return n;
+        }
+
+        return 0;
     }
 
     public static RuvProgram Create(int id, string channel, string name, string? foreignName, bool multipleEpisodes, string? slug = null, Uri? imageUrl = null, string? description = null)

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/SeasonNumber.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/SeasonNumber.cs
@@ -76,4 +76,95 @@ public sealed class SeasonNumber
         // Assert
         sut.SeasonNumber.ShouldBe(5);
     }
+
+    [Fact]
+    public void FallsBackToForeignNameRomanNumeral()
+    {
+        // Arrange / Act
+        RuvProgram sut = new RuvProgramBuilder()
+            .WithName("Lögregluvaktin")
+            .WithForeignName("Chicago PD IX")
+            .Build();
+
+        // Assert
+        sut.SeasonNumber.ShouldBe(9);
+    }
+
+    [Fact]
+    public void FallsBackToForeignNameInteger()
+    {
+        // Arrange / Act
+        RuvProgram sut = new RuvProgramBuilder()
+            .WithName("Lögregluvaktin")
+            .WithForeignName("Chicago PD 9")
+            .Build();
+
+        // Assert
+        sut.SeasonNumber.ShouldBe(9);
+    }
+
+    [Fact]
+    public void ForeignNameRomanNumeralX()
+    {
+        // Arrange / Act
+        RuvProgram sut = new RuvProgramBuilder()
+            .WithName("Séra Brown")
+            .WithForeignName("Father Brown X")
+            .Build();
+
+        // Assert
+        sut.SeasonNumber.ShouldBe(10);
+    }
+
+    [Fact]
+    public void ForeignNameRomanNumeralIII()
+    {
+        // Arrange / Act
+        RuvProgram sut = new RuvProgramBuilder()
+            .WithName("Kúlugúbbarnir")
+            .WithForeignName("Bubble Guppies III")
+            .Build();
+
+        // Assert
+        sut.SeasonNumber.ShouldBe(3);
+    }
+
+    [Fact]
+    public void NameTakesPrecedenceOverForeignName()
+    {
+        // Arrange / Act
+        RuvProgram sut = new RuvProgramBuilder()
+            .WithName("Dagskrá II")
+            .WithForeignName("Show IX")
+            .Build();
+
+        // Assert
+        sut.SeasonNumber.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ReturnsZeroWhenBothNamesLackSeason()
+    {
+        // Arrange / Act
+        RuvProgram sut = new RuvProgramBuilder()
+            .WithName("Dagskrá")
+            .WithForeignName("Some Show")
+            .Build();
+
+        // Assert
+        sut.SeasonNumber.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ReturnsZeroWhenForeignNameIsNull()
+    {
+        // Arrange / Act
+        RuvProgram sut = new RuvProgramBuilder()
+            .WithName("Dagskrá")
+            .WithForeignName(null)
+            .Build();
+
+        // Assert
+        sut.SeasonNumber.ShouldBe(0);
+    }
 }


### PR DESCRIPTION
## Summary
- Extract suffix-parsing into `ParseSeasonFromSuffix` private static method
- `SeasonNumber` falls back to `ForeignName` when `Name` yields no season number
- Fixes permanently unmatched episodes for Lögregluvaktin (Chicago PD IX → S9), Séra Brown (Father Brown X → S10), and Kúlugúbbarnir (Bubble Guppies III → S3)

## Test plan
- [ ] 7 new unit tests in `SeasonNumber.cs` covering Roman numeral fallback, integer fallback, Name precedence, both names lacking a season, and null ForeignName
- [ ] All existing tests pass (`dotnet test`)

Closes #285