### PR TITLE
Raise DownloadFailedEvent on MarkFailed

### DIFF
--- a/src/Ruvarr/Downloads/Domain/DownloadQueueItem.cs
+++ b/src/Ruvarr/Downloads/Domain/DownloadQueueItem.cs
@@ -47,5 +47,6 @@ internal sealed class DownloadQueueItem
     public void MarkFailed()
     {
         Status = DownloadQueueStatus.Failed;
+        _domainEvents.Add(new DownloadFailedEvent(this));
     }
 }

--- a/src/Ruvarr/Downloads/Events/DownloadFailedEvent.cs
+++ b/src/Ruvarr/Downloads/Events/DownloadFailedEvent.cs
@@ -1,0 +1,6 @@
+using Ruvarr.Abstractions;
+using Ruvarr.Downloads.Domain;
+
+namespace Ruvarr.Downloads.Events;
+
+internal sealed record DownloadFailedEvent(DownloadQueueItem Item) : IDomainEvent;

--- a/tests/Ruvarr.UnitTests/Downloads/Domain/DownloadQueueItemTests/DomainEvents.cs
+++ b/tests/Ruvarr.UnitTests/Downloads/Domain/DownloadQueueItemTests/DomainEvents.cs
@@ -37,6 +37,20 @@ public sealed class DomainEvents
     }
 
     [Fact]
+    public void MarkFailed_RaisesDownloadFailedEvent()
+    {
+        // Arrange
+        DownloadQueueItem sut = DownloadQueueItem.Create(new RuvEpisodeBuilder().Build());
+
+        // Act
+        sut.MarkFailed();
+
+        // Assert
+        DownloadFailedEvent @event = sut.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<DownloadFailedEvent>();
+        @event.Item.ShouldBe(sut);
+    }
+
+    [Fact]
     public void ClearDomainEvents_ClearsAllEvents()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Adds `DownloadFailedEvent` record implementing `IDomainEvent` under `Downloads/Events/`
- `MarkFailed()` now raises `DownloadFailedEvent`, consistent with `MarkDownloading()` and `MarkDownloaded()`
- Unit test verifies the event is raised with the correct item reference

## Test plan
- [x] All existing tests pass
- [x] `MarkFailed_RaisesDownloadFailedEvent` unit test covers the new behaviour

Closes #289