### PR TITLE
Fix flaky SonarrImport test by eliminating static DownloadsRoot

### DIFF
--- a/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
+++ b/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
@@ -55,13 +55,15 @@ internal class DownloadQueueProcessor(
         string filepath;
         try
         {
+            string downloadsRoot = settingsStore.Current.DownloadsRoot;
+
             string tentativePath = item.Episode.ToFilePath(
-                RuvarrSettings.DownloadsRoot,
+                downloadsRoot,
                 episodeSubdirectory,
                 fileAlreadyExists: false);
 
             filepath = item.Episode.ToFilePath(
-                RuvarrSettings.DownloadsRoot,
+                downloadsRoot,
                 episodeSubdirectory,
                 fileAlreadyExists: File.Exists(tentativePath));
 

--- a/src/Ruvarr/Program.cs
+++ b/src/Ruvarr/Program.cs
@@ -35,7 +35,7 @@ using (IServiceScope scope = app.Services.CreateScope())
 try
 {
     RuvarrSettings settings = app.Services.GetRequiredService<ISettingsStore>().Current;
-    Directory.CreateDirectory(RuvarrSettings.DownloadsRoot);
+    Directory.CreateDirectory(settings.DownloadsRoot);
     Directory.CreateDirectory(settings.ResolvedEpisodeDownloadDirectory);
     Directory.CreateDirectory(settings.ResolvedMovieDownloadDirectory);
 }

--- a/src/Ruvarr/Settings/Commands/SaveSettings/SaveSettingsHandler.cs
+++ b/src/Ruvarr/Settings/Commands/SaveSettings/SaveSettingsHandler.cs
@@ -49,14 +49,15 @@ internal sealed class SaveSettingsHandler(ISettingsStore store, ISchedulerFactor
             return SettingsErrors.MovieSubdirectoryAbsolute;
         }
 
-        string normalizedRoot = Path.GetFullPath(RuvarrSettings.DownloadsRoot + Path.DirectorySeparatorChar);
-        string normalizedEpisodePath = Path.GetFullPath(Path.Join(RuvarrSettings.DownloadsRoot, command.EpisodeDownloadDirectory));
+        string downloadsRoot = store.Current.DownloadsRoot;
+        string normalizedRoot = Path.GetFullPath(downloadsRoot + Path.DirectorySeparatorChar);
+        string normalizedEpisodePath = Path.GetFullPath(Path.Join(downloadsRoot, command.EpisodeDownloadDirectory));
         if (!normalizedEpisodePath.StartsWith(normalizedRoot, StringComparison.Ordinal))
         {
             return SettingsErrors.EpisodeSubdirectoryTraversal;
         }
 
-        string normalizedMoviePath = Path.GetFullPath(Path.Join(RuvarrSettings.DownloadsRoot, command.MovieDownloadDirectory));
+        string normalizedMoviePath = Path.GetFullPath(Path.Join(downloadsRoot, command.MovieDownloadDirectory));
         if (!normalizedMoviePath.StartsWith(normalizedRoot, StringComparison.Ordinal))
         {
             return SettingsErrors.MovieSubdirectoryTraversal;

--- a/src/Ruvarr/Settings/RuvarrSettings.cs
+++ b/src/Ruvarr/Settings/RuvarrSettings.cs
@@ -8,7 +8,7 @@ internal sealed record RuvarrSettings(
     string EpisodeDownloadDirectory = "tv",
     string MovieDownloadDirectory = "movies")
 {
-    public static string DownloadsRoot { get; internal set; } = "/downloads";
+    public string DownloadsRoot { get; init; } = "/downloads";
 
     public bool IslTranslationBackfillComplete { get; init; }
 

--- a/src/Ruvarr/Settings/Settings.razor
+++ b/src/Ruvarr/Settings/Settings.razor
@@ -6,6 +6,7 @@
 @using Ruvarr.Settings.Queries.GetSettings
 @using Ruvarr.Settings.Queries.TestSonarrConnection
 @inject IServiceScopeFactory ScopeFactory
+@inject ISettingsStore SettingsStore
 @implements IDisposable
 
 <h1>Settings</h1>
@@ -89,7 +90,7 @@ else
                 <label for="episode-download-dir">Episode Subdirectory</label>
                 <input id="episode-download-dir" type="text" @bind="_episodeDownloadDirectory" @bind:event="oninput" aria-describedby="episode-download-dir-resolved episode-download-dir-error" />
                 @{ var episodeTrimmed = _episodeDownloadDirectory.Trim('/'); }
-                <span id="episode-download-dir-resolved" class="resolved-path">@(string.IsNullOrEmpty(episodeTrimmed) ? RuvarrSettings.DownloadsRoot : System.IO.Path.Join(RuvarrSettings.DownloadsRoot, episodeTrimmed))</span>
+                <span id="episode-download-dir-resolved" class="resolved-path">@(string.IsNullOrEmpty(episodeTrimmed) ? SettingsStore.Current.DownloadsRoot : System.IO.Path.Join(SettingsStore.Current.DownloadsRoot, episodeTrimmed))</span>
                 @{
                     string? episodeDirError = null;
                     if (_fieldErrors.TryGetValue(SettingsErrors.EpisodeSubdirectoryAbsoluteCode, out string? e1))
@@ -115,7 +116,7 @@ else
                 <label for="movie-download-dir">Movie Subdirectory</label>
                 <input id="movie-download-dir" type="text" @bind="_movieDownloadDirectory" @bind:event="oninput" aria-describedby="movie-download-dir-resolved movie-download-dir-error" />
                 @{ var movieTrimmed = _movieDownloadDirectory.Trim('/'); }
-                <span id="movie-download-dir-resolved" class="resolved-path">@(string.IsNullOrEmpty(movieTrimmed) ? RuvarrSettings.DownloadsRoot : System.IO.Path.Join(RuvarrSettings.DownloadsRoot, movieTrimmed))</span>
+                <span id="movie-download-dir-resolved" class="resolved-path">@(string.IsNullOrEmpty(movieTrimmed) ? SettingsStore.Current.DownloadsRoot : System.IO.Path.Join(SettingsStore.Current.DownloadsRoot, movieTrimmed))</span>
                 @{
                     string? movieDirError = null;
                     if (_fieldErrors.TryGetValue(SettingsErrors.MovieSubdirectoryAbsoluteCode, out string? m1))

--- a/src/Ruvarr/Settings/SettingsStore.cs
+++ b/src/Ruvarr/Settings/SettingsStore.cs
@@ -78,7 +78,7 @@ internal sealed class SettingsStore : ISettingsStore, IDisposable
 
     private static RuvarrSettings MigrateAbsolutePaths(RuvarrSettings settings)
     {
-        string prefix = RuvarrSettings.DownloadsRoot + "/";
+        string prefix = settings.DownloadsRoot + "/";
 
         string episodeDir = settings.EpisodeDownloadDirectory;
         if (episodeDir.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))

--- a/tests/Ruvarr.UnitTests/Jobs/DownloadQueueProcessorTests/SonarrImport.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/DownloadQueueProcessorTests/SonarrImport.cs
@@ -26,18 +26,18 @@ public sealed class SonarrImport : IDisposable
     {
         _tempDownloadsRoot = Path.Combine(Path.GetTempPath(), $"ruvarr-test-{Guid.NewGuid()}");
         Directory.CreateDirectory(_tempDownloadsRoot);
-        RuvarrSettings.DownloadsRoot = _tempDownloadsRoot;
 
         _serviceProvider.GetService(Arg.Any<Type>()).Returns(Array.Empty<object>());
         _settingsStore.Current.Returns(new RuvarrSettings(
             SonarrBaseAddress: "http://sonarr", SonarrApiKey: "key",
-            EpisodeDownloadDirectory: "episodes"));
+            EpisodeDownloadDirectory: "episodes")
+        {
+            DownloadsRoot = _tempDownloadsRoot
+        });
     }
 
     public void Dispose()
     {
-        RuvarrSettings.DownloadsRoot = "/downloads";
-
         if (Directory.Exists(_tempDownloadsRoot))
         {
             Directory.Delete(_tempDownloadsRoot, recursive: true);
@@ -150,7 +150,7 @@ public sealed class SonarrImport : IDisposable
             Arg.Any<CancellationToken>());
     }
 
-    private static ManualImportFile CreateManualImportFile(
+    private ManualImportFile CreateManualImportFile(
         int? seriesId,
         IReadOnlyList<int> episodeIds,
         string filename = "Test.series.S01E01-RUV.mp4")
@@ -210,7 +210,7 @@ public sealed class SonarrImport : IDisposable
                 Id: id)).ToList();
 
         return new ManualImportFile(
-            Path: $"{RuvarrSettings.DownloadsRoot}/episodes/test/{filename}",
+            Path: $"{_tempDownloadsRoot}/episodes/test/{filename}",
             RelativePath: $"test/{filename}",
             Name: filename,
             Size: 1000,

--- a/tests/Ruvarr.UnitTests/Settings/Components/SettingsTests.cs
+++ b/tests/Ruvarr.UnitTests/Settings/Components/SettingsTests.cs
@@ -226,6 +226,10 @@ public sealed class SettingsTests : BunitContext
         handler.Handle(Arg.Any<GetSettingsQuery>(), Arg.Any<CancellationToken>())
             .Returns(new Result<RuvarrSettings>(settings));
         Services.AddSingleton(handler);
+
+        ISettingsStore settingsStore = Substitute.For<ISettingsStore>();
+        settingsStore.Current.Returns(settings);
+        Services.AddSingleton(settingsStore);
     }
 
     private IRequestHandler<SaveSettingsCommand> RegisterSaveSettingsHandler()

--- a/tests/Ruvarr.UnitTests/Settings/RuvarrSettingsTests/ResolvedPaths.cs
+++ b/tests/Ruvarr.UnitTests/Settings/RuvarrSettingsTests/ResolvedPaths.cs
@@ -59,9 +59,12 @@ public sealed class ResolvedPaths
     }
 
     [Fact]
-    public void DownloadsRoot_IsCorrectConstant()
+    public void DownloadsRoot_DefaultsToDownloads()
     {
+        // Arrange
+        RuvarrSettings settings = new();
+
         // Act & Assert
-        RuvarrSettings.DownloadsRoot.ShouldBe("/downloads");
+        settings.DownloadsRoot.ShouldBe("/downloads");
     }
 }

--- a/tests/Ruvarr.UnitTests/Settings/SettingsStoreTests/LoadFromFile.cs
+++ b/tests/Ruvarr.UnitTests/Settings/SettingsStoreTests/LoadFromFile.cs
@@ -9,13 +9,9 @@ namespace Ruvarr.UnitTests.Settings.SettingsStoreTests;
 public sealed class LoadFromFile : IDisposable
 {
     private readonly string _tempDir;
-    private readonly string _originalDownloadsRoot;
 
     public LoadFromFile()
     {
-        _originalDownloadsRoot = RuvarrSettings.DownloadsRoot;
-        RuvarrSettings.DownloadsRoot = "/downloads";
-
         _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(_tempDir);
     }
@@ -163,8 +159,6 @@ public sealed class LoadFromFile : IDisposable
 
     public void Dispose()
     {
-        RuvarrSettings.DownloadsRoot = _originalDownloadsRoot;
-
         if (Directory.Exists(_tempDir))
         {
             Directory.Delete(_tempDir, recursive: true);


### PR DESCRIPTION
## Summary
- `RuvarrSettings.DownloadsRoot` was a `static` mutable property set and reset in test constructors/Dispose methods
- `SonarrImport` and `LoadFromFile` test classes both modified it, racing under xUnit's default parallel execution
- When `LoadFromFile.Dispose()` reset it to `"/downloads"` mid-test, `DownloadQueueProcessor` tried to create `/downloads/episodes/...` in CI, hit an `IOException`, and returned early — `ManualImportFilesAsync` was never called
- Converts `DownloadsRoot` to an `init` property on `RuvarrSettings` (default `"/downloads"`); all consumers now read from `ISettingsStore.Current`

## Test plan
- [x] All 677 unit tests pass
- [x] No warnings in build
- [x] `ImportsEpisode_WhenSeriesExistsInSonarr` passes consistently in CI

Closes #288