### PR TITLE
Extract duplicated missing-episodes fetch into GetMissingTvdbIdsAsync

### DIFF
--- a/src/Ruvarr/Infrastructure/Sonarr/SonarrClientExtensions.cs
+++ b/src/Ruvarr/Infrastructure/Sonarr/SonarrClientExtensions.cs
@@ -1,0 +1,14 @@
+using Ruvarr.Infrastructure.Sonarr.Models;
+
+namespace Ruvarr.Infrastructure.Sonarr;
+
+internal static class SonarrClientExtensions
+{
+    public static async Task<HashSet<int>> GetMissingTvdbIdsAsync(
+        this ISonarrClient sonarr,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyCollection<MissingEpisode> missingEpisodes = await sonarr.GetMissingEpisodesAsync(cancellationToken: cancellationToken);
+        return [.. missingEpisodes.Select(x => x.TvdbId)];
+    }
+}

--- a/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
+++ b/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
@@ -51,12 +51,12 @@ internal sealed class RuvEpisodesSyncJob(
             .Where(x => x.HasMultipleEpisodes)
             .ToListAsync();
 
-        IReadOnlyCollection<MissingEpisode> missingEpisodes;
+        HashSet<int> missingTvdbIds;
         IReadOnlyList<Series> sonarrSeries;
 
         try
         {
-            missingEpisodes = await sonarr.GetMissingEpisodesAsync();
+            missingTvdbIds = await sonarr.GetMissingTvdbIdsAsync(CancellationToken.None);
             sonarrSeries = await sonarr.GetSeriesAsync();
         }
 #pragma warning disable CA1031 // Catch all exceptions to prevent queue items from getting stuck in Processing state
@@ -73,8 +73,6 @@ internal sealed class RuvEpisodesSyncJob(
             broadcaster.Publish(new QueueChangedEvent<ProgramRefreshQueueItemSummary>());
             return;
         }
-
-        HashSet<int> missingTvdbIds = [.. missingEpisodes.Select(x => x.TvdbId)];
 
         HashSet<int> monitoredTvdbIds = [.. sonarrSeries
             .Where(x => x.Monitored)

--- a/src/Ruvarr/Programs/Commands/MatchEpisode/MatchEpisodeHandler.cs
+++ b/src/Ruvarr/Programs/Commands/MatchEpisode/MatchEpisodeHandler.cs
@@ -2,7 +2,6 @@
 
 using Ruvarr.Abstractions;
 using Ruvarr.Infrastructure.Sonarr;
-using Ruvarr.Infrastructure.Sonarr.Models;
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
 using Ruvarr.Programs.Domain;
@@ -37,8 +36,7 @@ internal sealed class MatchEpisodeHandler(
             return ProgramErrors.EpisodeNotFound;
         }
 
-        IReadOnlyCollection<MissingEpisode> missingEpisodes = await sonarr.GetMissingEpisodesAsync(cancellationToken: cancellationToken);
-        HashSet<int> missingTvdbIds = [.. missingEpisodes.Select(x => x.TvdbId)];
+        HashSet<int> missingTvdbIds = await sonarr.GetMissingTvdbIdsAsync(cancellationToken);
 
         List<TvdbEpisode> tvdbEpisodes = [];
         foreach (int tvdbId in command.TvdbIds)

--- a/src/Ruvarr/Programs/Commands/MatchProgramEpisodes/MatchProgramEpisodesHandler.cs
+++ b/src/Ruvarr/Programs/Commands/MatchProgramEpisodes/MatchProgramEpisodesHandler.cs
@@ -2,7 +2,6 @@
 
 using Ruvarr.Abstractions;
 using Ruvarr.Infrastructure.Sonarr;
-using Ruvarr.Infrastructure.Sonarr.Models;
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
 using Ruvarr.Programs.Domain;
@@ -55,8 +54,7 @@ internal sealed class MatchProgramEpisodesHandler(
             return ProgramErrors.ProgramEpisodeCountMismatch;
         }
 
-        IReadOnlyCollection<MissingEpisode> missingEpisodes = await sonarr.GetMissingEpisodesAsync(cancellationToken: cancellationToken);
-        HashSet<int> missingTvdbIds = [.. missingEpisodes.Select(x => x.TvdbId)];
+        HashSet<int> missingTvdbIds = await sonarr.GetMissingTvdbIdsAsync(cancellationToken);
 
         foreach (RuvEpisode episode in program.Episodes)
         {

--- a/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
+++ b/src/Ruvarr/TvdbEpisodeLookup/Jobs/TvdbEpisodeLookupJob.cs
@@ -5,7 +5,6 @@ using Quartz;
 using Ruvarr.Abstractions;
 using Ruvarr.Contracts;
 using Ruvarr.Infrastructure.Sonarr;
-using Ruvarr.Infrastructure.Sonarr.Models;
 using Ruvarr.Infrastructure.Tvdb;
 using Ruvarr.Infrastructure.Tvdb.Models;
 using Ruvarr.Programs.Domain;
@@ -68,8 +67,7 @@ internal sealed class TvdbEpisodeLookupJob(
                 return;
             }
 
-            IReadOnlyCollection<MissingEpisode> missingEpisodes = await sonarr.GetMissingEpisodesAsync();
-            HashSet<int> missingTvdbIds = [.. missingEpisodes.Select(x => x.TvdbId)];
+            HashSet<int> missingTvdbIds = await sonarr.GetMissingTvdbIdsAsync(context?.CancellationToken ?? CancellationToken.None);
 
             EpisodeMatchingContext matchingContext = new(program, seriesData, missingTvdbIds);
             await matcher.MatchAsync(matchingContext, context?.CancellationToken ?? CancellationToken.None);

--- a/tests/Ruvarr.UnitTests/Infrastructure/Sonarr/SonarrClientExtensionsTests.cs
+++ b/tests/Ruvarr.UnitTests/Infrastructure/Sonarr/SonarrClientExtensionsTests.cs
@@ -1,0 +1,104 @@
+using NSubstitute;
+
+using Ruvarr.Infrastructure.Sonarr;
+using Ruvarr.Infrastructure.Sonarr.Models;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Infrastructure.Sonarr;
+
+public sealed class SonarrClientExtensionsTests
+{
+    private static MissingEpisode CreateMissingEpisode(int tvdbId) =>
+        new(
+            Id: 1,
+            SeriesId: 10,
+            TvdbId: tvdbId,
+            EpisodeFileId: 0,
+            SeasonNumber: 1,
+            Episodenumber: 1,
+            AbsoluteEpisodeNumber: 1,
+            Title: "Test Episode",
+            Overview: "Overview",
+            FinaleType: "",
+            AirDate: new DateOnly(2025, 1, 1),
+            AirDateUtc: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Runtime: 30,
+            HasFile: false,
+            Monitored: true,
+            UnverifiedSceneNumbering: false,
+            LastSearchTime: DateTime.UtcNow);
+
+    [Fact]
+    public async Task GetMissingTvdbIdsAsync_ReturnsHashSetOfTvdbIds()
+    {
+        // Arrange
+        ISonarrClient sonarr = Substitute.For<ISonarrClient>();
+        IReadOnlyCollection<MissingEpisode> missingEpisodes =
+        [
+            CreateMissingEpisode(100),
+            CreateMissingEpisode(200),
+            CreateMissingEpisode(300)
+        ];
+        sonarr.GetMissingEpisodesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(missingEpisodes);
+
+        // Act
+        HashSet<int> result = await sonarr.GetMissingTvdbIdsAsync(CancellationToken.None);
+
+        // Assert
+        result.ShouldBe(new HashSet<int> { 100, 200, 300 });
+    }
+
+    [Fact]
+    public async Task GetMissingTvdbIdsAsync_WithNoMissingEpisodes_ReturnsEmptySet()
+    {
+        // Arrange
+        ISonarrClient sonarr = Substitute.For<ISonarrClient>();
+        sonarr.GetMissingEpisodesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        // Act
+        HashSet<int> result = await sonarr.GetMissingTvdbIdsAsync(CancellationToken.None);
+
+        // Assert
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetMissingTvdbIdsAsync_WithDuplicateTvdbIds_ReturnsDistinctSet()
+    {
+        // Arrange
+        ISonarrClient sonarr = Substitute.For<ISonarrClient>();
+        IReadOnlyCollection<MissingEpisode> missingEpisodes =
+        [
+            CreateMissingEpisode(100),
+            CreateMissingEpisode(100)
+        ];
+        sonarr.GetMissingEpisodesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(missingEpisodes);
+
+        // Act
+        HashSet<int> result = await sonarr.GetMissingTvdbIdsAsync(CancellationToken.None);
+
+        // Assert
+        result.Count.ShouldBe(1);
+        result.ShouldContain(100);
+    }
+
+    [Fact]
+    public async Task GetMissingTvdbIdsAsync_PassesCancellationToken()
+    {
+        // Arrange
+        ISonarrClient sonarr = Substitute.For<ISonarrClient>();
+        sonarr.GetMissingEpisodesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        using CancellationTokenSource cts = new();
+
+        // Act
+        await sonarr.GetMissingTvdbIdsAsync(cts.Token);
+
+        // Assert
+        await sonarr.Received(1).GetMissingEpisodesAsync(Arg.Any<int>(), cts.Token);
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts the repeated `GetMissingEpisodesAsync → HashSet<int> missingTvdbIds` pattern into a new `ISonarrClient` extension method `GetMissingTvdbIdsAsync`
- Updates all 4 call sites: `MatchEpisodeHandler`, `MatchProgramEpisodesHandler`, `TvdbEpisodeLookupJob`, `RuvEpisodesSyncJob`
- Adds 4 unit tests covering normal use, empty results, duplicate IDs, and cancellation token forwarding

## Test plan
- [x] All existing tests pass (`dotnet test`)
- [x] New `SonarrClientExtensionsTests` cover the extracted logic

Closes #294