### PR TITLE
Clear filters button now resets search text

### DIFF
--- a/src/Ruvarr/Programs/Filters/ProgramsFilterState.cs
+++ b/src/Ruvarr/Programs/Filters/ProgramsFilterState.cs
@@ -21,7 +21,8 @@ internal sealed class ProgramsFilterState
         FilterPendingLookup != PendingLookupFilter.All ||
         FilterForeignName != ForeignNameFilter.All ||
         FilterEpisodeMatch != EpisodeMatchFilter.All ||
-        !string.IsNullOrEmpty(FilterChannel);
+        !string.IsNullOrEmpty(FilterChannel) ||
+        HasSearchText;
 
     public void Clear()
     {
@@ -32,6 +33,7 @@ internal sealed class ProgramsFilterState
         FilterForeignName = ForeignNameFilter.All;
         FilterEpisodeMatch = EpisodeMatchFilter.All;
         FilterChannel = string.Empty;
+        SearchText = string.Empty;
         ScrollPositionY = 0;
     }
 }

--- a/tests/Ruvarr.UnitTests/Programs/ProgramsFilterStateTests/Clear.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramsFilterStateTests/Clear.cs
@@ -36,7 +36,7 @@ public sealed class Clear
     }
 
     [Fact]
-    public void DoesNotResetSearchText()
+    public void ResetsSearchText()
     {
         // Arrange
         ProgramsFilterState sut = new() { SearchText = "test query" };
@@ -45,7 +45,7 @@ public sealed class Clear
         sut.Clear();
 
         // Assert
-        sut.SearchText.ShouldBe("test query");
+        sut.SearchText.ShouldBeEmpty();
     }
 
     [Fact]

--- a/tests/Ruvarr.UnitTests/Programs/ProgramsFilterStateTests/HasActiveFilters.cs
+++ b/tests/Ruvarr.UnitTests/Programs/ProgramsFilterStateTests/HasActiveFilters.cs
@@ -202,7 +202,7 @@ public sealed class HasActiveFilters
     }
 
     [Fact]
-    public void ReturnsFalseWhenOnlySearchTextIsSet()
+    public void ReturnsTrueWhenSearchTextIsSet()
     {
         // Arrange
         ProgramsFilterState sut = new() { SearchText = "test" };
@@ -211,6 +211,6 @@ public sealed class HasActiveFilters
         bool result = sut.HasActiveFilters;
 
         // Assert
-        result.ShouldBeFalse();
+        result.ShouldBeTrue();
     }
 }


### PR DESCRIPTION
## Summary
- `FilterState.Clear()` now resets `SearchText` to `string.Empty`
- `HasActiveFilters` now returns `true` when `SearchText` is non-empty

## Test plan
- [ ] Click "Clear filters" with search text populated — input clears
- [ ] Type in search box only — "Clear filters" button becomes enabled
- [ ] All 752 unit tests pass

Closes #233