### PR TITLE
chore(ci): simplify deploy script to use git reset instead of checkout/pull

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-REPO=/mnt/user/appdata/ruvarr
+REPO=/mnt/user/appdata/ruvarr-src
 LOG_PREFIX="$(date '+%Y-%m-%d %H:%M:%S')"
 
 cd "$REPO"


### PR DESCRIPTION
## Summary
- Add \`deploy.sh\` to the repo for the first time (previously only existed on the server)
- Replace \`git checkout main\` + \`git pull\` with \`git reset --hard origin/main\` + \`git clean -fd\` — simpler and prevents failures when files have been edited directly on the server