### PR TITLE
Show episode count in programs page

### DIFF
--- a/src/Ruvarr/Contracts/ProgramSummary.cs
+++ b/src/Ruvarr/Contracts/ProgramSummary.cs
@@ -13,4 +13,5 @@ public sealed record ProgramSummary(
     EpisodeMatchStatus EpisodeMatchStatus,
     Uri? ImageUrl,
     bool IsMovieMatch,
-    string? Description);
+    string? Description,
+    int EpisodeCount);

--- a/src/Ruvarr/Programs/Programs.razor
+++ b/src/Ruvarr/Programs/Programs.razor
@@ -137,6 +137,7 @@ else
                     <th>Program</th>
                     <th>Channel</th>
                     <th>TVDB Series</th>
+                    <th class="col-center">Episodes</th>
                     <th class="col-center"></th>
                     <th class="col-center"></th>
                     <th class="col-center"></th>
@@ -162,6 +163,7 @@ else
                                 <span class="unmatched-dash">—</span>
                             }
                         </td>
+                        <td class="col-center">@program.EpisodeCount</td>
                         <td class="col-center">
                             @if (program.HasMissingEpisodes)
                             {

--- a/src/Ruvarr/Programs/Queries/GetProgram/GetProgramHandler.cs
+++ b/src/Ruvarr/Programs/Queries/GetProgram/GetProgramHandler.cs
@@ -27,6 +27,7 @@ internal sealed class GetProgramHandler(RuvarrDbContext dbContext) : IRequestHan
                 HasSeries = x.Series != null,
                 x.ImageUrl,
                 x.Description,
+                EpisodeCount = x.Episodes.Count,
                 HasAnyEpisodes = x.Episodes.Any(),
                 AllEpisodesMatched = x.Episodes.All(e => e.TvdbEpisodes.Any()),
                 AnyEpisodeMatched = x.Episodes.Any(e => e.TvdbEpisodes.Any()),
@@ -55,7 +56,8 @@ internal sealed class GetProgramHandler(RuvarrDbContext dbContext) : IRequestHan
             matchStatus,
             projected.ImageUrl,
             projected.HasMovie,
-            projected.Description);
+            projected.Description,
+            projected.EpisodeCount);
     }
 
     private static EpisodeMatchStatus DeriveEpisodeMatchStatus(bool hasSeries, bool hasAnyEpisodes, bool allEpisodesMatched, bool anyEpisodeMatched)

--- a/src/Ruvarr/Programs/Queries/GetPrograms/GetProgramsHandler.cs
+++ b/src/Ruvarr/Programs/Queries/GetPrograms/GetProgramsHandler.cs
@@ -30,6 +30,7 @@ internal sealed class GetProgramsHandler(RuvarrDbContext dbContext) : IStreaming
                 SeriesSlug = x.Series!.Slug,
                 SeriesTvdbId = (int?)x.Series!.TvdbId,
                 HasSeries = x.Series != null,
+                EpisodeCount = x.Episodes.Count,
                 HasAnyEpisodes = x.Episodes.Any(),
                 AllEpisodesMatched = x.Episodes.All(e => e.TvdbEpisodes.Any()),
                 AnyEpisodeMatched = x.Episodes.Any(e => e.TvdbEpisodes.Any()),
@@ -49,7 +50,8 @@ internal sealed class GetProgramsHandler(RuvarrDbContext dbContext) : IStreaming
                 DeriveEpisodeMatchStatus(x.HasSeries, x.HasAnyEpisodes, x.AllEpisodesMatched, x.AnyEpisodeMatched),
                 null,
                 x.HasMovie,
-                null));
+                null,
+                x.EpisodeCount));
 
         await foreach (ProgramSummary summary in results.WithCancellation(cancellationToken))
         {

--- a/src/Ruvarr/wwwroot/app.css
+++ b/src/Ruvarr/wwwroot/app.css
@@ -584,7 +584,10 @@ dialog input[type="number"]:focus {
 .programs-table td:nth-child(6) { width: 1%; white-space: nowrap; text-align: center; }
 
 .programs-table th:nth-child(7),
-.programs-table td:nth-child(7) { width: 1%; white-space: nowrap; }
+.programs-table td:nth-child(7) { width: 1%; white-space: nowrap; text-align: center; }
+
+.programs-table th:nth-child(8),
+.programs-table td:nth-child(8) { width: 1%; white-space: nowrap; }
 
 .col-center { text-align: center; }
 .col-center svg { display: block; margin: 0 auto; }

--- a/tests/Ruvarr.IntegrationTests/Programs/Queries/GetProgramHandlerTests.cs
+++ b/tests/Ruvarr.IntegrationTests/Programs/Queries/GetProgramHandlerTests.cs
@@ -58,6 +58,7 @@ public sealed class GetProgramHandlerTests(IntegrationTestFactory factory) : ICl
         result.Channel.ShouldBe("RÚV1");
         result.SeriesName.ShouldBe("Detail Series");
         result.TvdbUrl.ShouldBe(new Uri("https://www.thetvdb.com/series/detail-series"));
+        result.EpisodeCount.ShouldBe(0);
     }
 
     [Fact]
@@ -217,6 +218,36 @@ public sealed class GetProgramHandlerTests(IntegrationTestFactory factory) : ICl
         // Assert
         result.ShouldNotBeNull();
         result.Description.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ReturnsEpisodeCount()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+        IRequestHandler<GetProgramQuery, ProgramSummary?> handler =
+            scope.ServiceProvider.GetRequiredService<IRequestHandler<GetProgramQuery, ProgramSummary?>>();
+
+        RuvProgram program = new RuvProgramBuilder()
+            .WithRuvId(40040)
+            .WithMultipleEpisodes()
+            .Build();
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        program.TryAddEpisode("EP1", new Uri("https://example.com/ep1.mp4"), "Episode 1", "Desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("EP2", new Uri("https://example.com/ep2.mp4"), "Episode 2", "Desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        ProgramSummary? result = await handler.Handle(new GetProgramQuery(40040), cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.EpisodeCount.ShouldBe(2);
     }
 
     [Fact]

--- a/tests/Ruvarr.IntegrationTests/Programs/Queries/GetProgramsHandlerTests.cs
+++ b/tests/Ruvarr.IntegrationTests/Programs/Queries/GetProgramsHandlerTests.cs
@@ -51,6 +51,7 @@ public sealed class GetProgramsHandlerTests(IntegrationTestFactory factory) : IC
         found.Channel.ShouldBe("RÚV1");
         found.ProgramName.ShouldBe("Test Program");
         found.SeriesName.ShouldBeNull();
+        found.EpisodeCount.ShouldBe(1);
     }
 
     [Fact]
@@ -820,5 +821,62 @@ public sealed class GetProgramsHandlerTests(IntegrationTestFactory factory) : IC
         // Assert
         result.ShouldContain(p => p.ProgramRuvId == 40005);
         result.ShouldNotContain(p => p.ProgramRuvId == 40006);
+    }
+
+    [Fact]
+    public async Task ReturnsEpisodeCount()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+        IStreamingRequestHandler<GetProgramsQuery, ProgramSummary> handler =
+            scope.ServiceProvider.GetRequiredService<IStreamingRequestHandler<GetProgramsQuery, ProgramSummary>>();
+
+        RuvProgram program = RuvProgram.Create(50001, "RÚV1", "Episode Count Program", null, multipleEpisodes: true);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        program.TryAddEpisode("EC-EP1", new Uri("https://example.com/ec-ep1.mp4"), "Episode 1", "Desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("EC-EP2", new Uri("https://example.com/ec-ep2.mp4"), "Episode 2", "Desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("EC-EP3", new Uri("https://example.com/ec-ep3.mp4"), "Episode 3", "Desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary> result = await handler
+            .Handle(new GetProgramsQuery(null, null, null, null, null, null, null), cancellationToken)
+            .ToListAsync(cancellationToken);
+
+        // Assert
+        ProgramSummary? found = result.FirstOrDefault(p => p.ProgramRuvId == 50001);
+        found.ShouldNotBeNull();
+        found.EpisodeCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task ReturnsZeroEpisodeCountWhenProgramHasNoEpisodes()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        RuvarrDbContext dbContext = scope.ServiceProvider.GetRequiredService<RuvarrDbContext>();
+        IStreamingRequestHandler<GetProgramsQuery, ProgramSummary> handler =
+            scope.ServiceProvider.GetRequiredService<IStreamingRequestHandler<GetProgramsQuery, ProgramSummary>>();
+
+        RuvProgram program = RuvProgram.Create(50002, "RÚV1", "Zero Episode Count Program", null, multipleEpisodes: true);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Act
+        List<ProgramSummary> result = await handler
+            .Handle(new GetProgramsQuery(null, null, null, null, null, null, null), cancellationToken)
+            .ToListAsync(cancellationToken);
+
+        // Assert
+        ProgramSummary? found = result.FirstOrDefault(p => p.ProgramRuvId == 50002);
+        found.ShouldNotBeNull();
+        found.EpisodeCount.ShouldBe(0);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `EpisodeCount` to `ProgramSummary` DTO
- Projects episode count via `x.Episodes.Count` in EF Core queries (single SQL subquery, no N+1)
- Renders a new "Episodes" column in the Programs page table
- Updates CSS nth-child rules to accommodate the new column

## Test plan
- [x] Integration tests pass for `GetProgramsHandler` and `GetProgramHandler` (new `EpisodeCount` assertions added)
- [x] All 770 tests pass (`dotnet test`)
- [x] Programs page displays episode count column correctly

Closes #200