### PR TITLE
chore: ignore .superpowers/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Claude Code
 CLAUDE.md
 .claude/
+.superpowers/
 
 # Git worktrees
 .worktrees/


### PR DESCRIPTION
Adds `.superpowers/` to `.gitignore` to prevent the Claude Code superpowers skill directory from being tracked.