### PR TITLE
fix(sonarr): pass seriesId to manual import API for non-English series

### DIFF
--- a/src/Ruvarr/Infrastructure/Sonarr/CachingSonarrClient.cs
+++ b/src/Ruvarr/Infrastructure/Sonarr/CachingSonarrClient.cs
@@ -77,8 +77,9 @@ internal sealed class CachingSonarrClient(
 
     public Task<IReadOnlyList<ManualImportFile>> GetManualImportsAsync(
         string folder,
+        int? seriesId = null,
         CancellationToken cancellationToken = default) =>
-        innerClientFactory().GetManualImportsAsync(folder, cancellationToken);
+        innerClientFactory().GetManualImportsAsync(folder, seriesId, cancellationToken);
 
     public Task<IReadOnlyList<RootFolder>> GetRootFoldersAsync(CancellationToken cancellationToken = default) =>
         innerClientFactory().GetRootFoldersAsync(cancellationToken);

--- a/src/Ruvarr/Infrastructure/Sonarr/ISonarrClient.cs
+++ b/src/Ruvarr/Infrastructure/Sonarr/ISonarrClient.cs
@@ -6,7 +6,7 @@ namespace Ruvarr.Infrastructure.Sonarr;
 internal interface ISonarrClient
 {
     Task<IReadOnlyList<Series>> GetSeriesAsync(CancellationToken cancellationToken = default);
-    Task<IReadOnlyList<ManualImportFile>> GetManualImportsAsync(string folder, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ManualImportFile>> GetManualImportsAsync(string folder, int? seriesId = null, CancellationToken cancellationToken = default);
     Task<IReadOnlyCollection<MissingEpisode>> GetMissingEpisodesAsync(int pageSize = int.MaxValue, CancellationToken cancellationToken = default);
     Task ManualImportFilesAsync(IEnumerable<ManualImportRequest> files, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<RootFolder>> GetRootFoldersAsync(CancellationToken cancellationToken = default);

--- a/src/Ruvarr/Infrastructure/Sonarr/SonarrClient.cs
+++ b/src/Ruvarr/Infrastructure/Sonarr/SonarrClient.cs
@@ -27,10 +27,12 @@ internal sealed class SonarrClient(ILogger<SonarrClient> logger, HttpClient http
     public Task ManualImportFilesAsync(IEnumerable<ManualImportRequest> files, CancellationToken cancellationToken = default) =>
         PostAsync("api/v3/command", new ManualImportCommand(files), cancellationToken);
 
-    public Task<IReadOnlyList<ManualImportFile>> GetManualImportsAsync(string folder, CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<ManualImportFile>> GetManualImportsAsync(string folder, int? seriesId = null, CancellationToken cancellationToken = default)
     {
         NameValueCollection parameters = HttpUtility.ParseQueryString(string.Empty);
         parameters.Add("folder", folder);
+        if (seriesId.HasValue)
+            parameters.Add("seriesId", $"{seriesId.Value}");
 
         string path = $"api/v3/manualimport?{HttpUtility.UrlPathEncode(parameters.ToString())}";
 

--- a/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
+++ b/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
@@ -132,7 +132,15 @@ internal class DownloadQueueProcessor(
 
         try
         {
-            IReadOnlyList<ManualImportFile> manualImportFiles = await sonarr.GetManualImportsAsync(settingsStore.Current.ResolvedEpisodeDownloadDirectory);
+            IReadOnlyList<Series> sonarrSeries = await sonarr.GetSeriesAsync(context.CancellationToken);
+            int? sonarrSeriesId = sonarrSeries
+                .FirstOrDefault(s => s.TvdbId == item.Episode.Program.Series?.TvdbId)
+                ?.Id;
+
+            IReadOnlyList<ManualImportFile> manualImportFiles = await sonarr.GetManualImportsAsync(
+                settingsStore.Current.ResolvedEpisodeDownloadDirectory,
+                sonarrSeriesId,
+                context.CancellationToken);
 
             ManualImportFile file = manualImportFiles.First(x => x.Path.EndsWith(filename, StringComparison.OrdinalIgnoreCase));
 

--- a/tests/Ruvarr.UnitTests/Jobs/DownloadQueueProcessorTests/ExceptionHandling.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/DownloadQueueProcessorTests/ExceptionHandling.cs
@@ -70,7 +70,7 @@ public sealed class ExceptionHandling
         dbContext.Set<DownloadQueueItem>().Add(item);
         await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("Sonarr unavailable"));
 
         DownloadQueueProcessor sut = CreateJob(dbContext);

--- a/tests/Ruvarr.UnitTests/Jobs/DownloadQueueProcessorTests/SettingsGate.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/DownloadQueueProcessorTests/SettingsGate.cs
@@ -77,6 +77,6 @@ public sealed class SettingsGate
 
         // Assert
         item.Status.ShouldBe(DownloadQueueStatus.Pending);
-        _ = _sonarr.DidNotReceive().GetManualImportsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        _ = _sonarr.DidNotReceive().GetManualImportsAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Ruvarr.UnitTests/Jobs/DownloadQueueProcessorTests/SonarrImport.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/DownloadQueueProcessorTests/SonarrImport.cs
@@ -92,7 +92,7 @@ public sealed class SonarrImport : IDisposable
             seriesId: 42,
             episodeIds: [101]);
 
-        _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns([file]);
 
         DownloadQueueProcessor sut = CreateJob(dbContext);
@@ -120,7 +120,7 @@ public sealed class SonarrImport : IDisposable
             seriesId: null,
             episodeIds: [101]);
 
-        _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns([file]);
 
         DownloadQueueProcessor sut = CreateJob(dbContext);
@@ -145,7 +145,7 @@ public sealed class SonarrImport : IDisposable
             seriesId: 42,
             episodeIds: []);
 
-        _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns([file]);
 
         DownloadQueueProcessor sut = CreateJob(dbContext);


### PR DESCRIPTION
## Summary

- Sonarr's manual import API now receives the matched series ID when scanning for downloaded files
- Fixes imports silently skipping when the download folder uses the original-language series name (e.g. "Karsten og Petra") instead of the English name Sonarr knows ("Casper and Emma")
- `GetManualImportsAsync` accepts an optional `seriesId` parameter that is appended to the Sonarr query string when present

## Test plan

- [x] Build passes with no warnings (`dotnet build`)
- [x] All tests pass (`dotnet test`)
- [ ] Queue a download for a series whose TVDB name differs from its Sonarr/English name and confirm it imports automatically