### PR TITLE
fix(sonarr): fall back to episode lookup when filename doesn't match series title

### DIFF
--- a/src/Ruvarr/Infrastructure/Sonarr/CachingSonarrClient.cs
+++ b/src/Ruvarr/Infrastructure/Sonarr/CachingSonarrClient.cs
@@ -75,6 +75,9 @@ internal sealed class CachingSonarrClient(
     public Task<IReadOnlyList<Series>> GetSeriesAsync(CancellationToken cancellationToken = default) =>
         innerClientFactory().GetSeriesAsync(cancellationToken);
 
+    public Task<IReadOnlyList<SonarrEpisode>> GetEpisodesAsync(int seriesId, CancellationToken cancellationToken = default) =>
+        innerClientFactory().GetEpisodesAsync(seriesId, cancellationToken);
+
     public Task<IReadOnlyList<ManualImportFile>> GetManualImportsAsync(
         string folder,
         int? seriesId = null,

--- a/src/Ruvarr/Infrastructure/Sonarr/ISonarrClient.cs
+++ b/src/Ruvarr/Infrastructure/Sonarr/ISonarrClient.cs
@@ -6,6 +6,7 @@ namespace Ruvarr.Infrastructure.Sonarr;
 internal interface ISonarrClient
 {
     Task<IReadOnlyList<Series>> GetSeriesAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<SonarrEpisode>> GetEpisodesAsync(int seriesId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<ManualImportFile>> GetManualImportsAsync(string folder, int? seriesId = null, CancellationToken cancellationToken = default);
     Task<IReadOnlyCollection<MissingEpisode>> GetMissingEpisodesAsync(int pageSize = int.MaxValue, CancellationToken cancellationToken = default);
     Task ManualImportFilesAsync(IEnumerable<ManualImportRequest> files, CancellationToken cancellationToken = default);

--- a/src/Ruvarr/Infrastructure/Sonarr/Models/SonarrEpisode.cs
+++ b/src/Ruvarr/Infrastructure/Sonarr/Models/SonarrEpisode.cs
@@ -1,0 +1,3 @@
+namespace Ruvarr.Infrastructure.Sonarr.Models;
+
+internal sealed record class SonarrEpisode(int Id, int SeriesId, int SeasonNumber, int EpisodeNumber);

--- a/src/Ruvarr/Infrastructure/Sonarr/SonarrClient.cs
+++ b/src/Ruvarr/Infrastructure/Sonarr/SonarrClient.cs
@@ -12,6 +12,9 @@ internal sealed class SonarrClient(ILogger<SonarrClient> logger, HttpClient http
     public Task<IReadOnlyList<Series>> GetSeriesAsync(CancellationToken cancellationToken = default) =>
         GetMany<Series>("api/v3/series", cancellationToken);
 
+    public Task<IReadOnlyList<SonarrEpisode>> GetEpisodesAsync(int seriesId, CancellationToken cancellationToken = default) =>
+        GetMany<SonarrEpisode>($"api/v3/episode?seriesId={seriesId}", cancellationToken);
+
     public async Task<IReadOnlyCollection<MissingEpisode>> GetMissingEpisodesAsync(int pageSize = int.MaxValue, CancellationToken cancellationToken = default)
     {
         NameValueCollection parameters = HttpUtility.ParseQueryString(string.Empty);

--- a/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
+++ b/src/Ruvarr/Jobs/DownloadQueueProcessor.cs
@@ -139,33 +139,67 @@ internal class DownloadQueueProcessor(
 
             IReadOnlyList<ManualImportFile> manualImportFiles = await sonarr.GetManualImportsAsync(
                 settingsStore.Current.ResolvedEpisodeDownloadDirectory,
-                sonarrSeriesId,
+                seriesId: null,
                 context.CancellationToken);
 
             ManualImportFile file = manualImportFiles.First(x => x.Path.EndsWith(filename, StringComparison.OrdinalIgnoreCase));
 
-            if (file.Series is null)
+            if (file.Series is not null)
             {
-                logger.LogWarning("Sonarr did not match {Episode} to a series. Skipping import", item.Episode.ToString());
+                if (file.Episodes.Count == 0)
+                {
+                    logger.LogWarning("Sonarr matched {Episode} to series {SeriesId} but found no episodes. Skipping import",
+                        item.Episode.ToString(), file.Series.Id);
+                    return;
+                }
+
+                ManualImportRequest request = new(
+                    Path: file.Path,
+                    SeriesId: file.Series.Id,
+                    EpisodeIds: file.Episodes.Select(e => e.Id).ToList(),
+                    Quality: file.Quality,
+                    Languages: file.Languages,
+                    ReleaseGroup: "RUV");
+
+                logger.LogInformation("Importing {Episode} into Sonarr", item.Episode.ToString());
+                await sonarr.ManualImportFilesAsync([request]);
                 return;
             }
 
-            if (file.Episodes.Count == 0)
+            if (sonarrSeriesId is null)
             {
-                logger.LogWarning("Sonarr matched {Episode} to series {SeriesId} but found no episodes. Skipping import", item.Episode.ToString(), file.Series.Id);
+                logger.LogWarning("Sonarr did not match {Episode} to a series and no Sonarr series ID is known. Skipping import",
+                    item.Episode.ToString());
                 return;
             }
 
-            ManualImportRequest request = new(
+            IReadOnlyList<SonarrEpisode> sonarrEpisodes = await sonarr.GetEpisodesAsync(
+                sonarrSeriesId.Value, context.CancellationToken);
+
+            List<int> matchedEpisodeIds = item.Episode.TvdbEpisodes
+                .Select(tvdbEp => sonarrEpisodes
+                    .FirstOrDefault(se => se.SeasonNumber == tvdbEp.SeasonNumber && se.EpisodeNumber == tvdbEp.EpisodeNumber))
+                .Where(se => se is not null)
+                .Select(se => se!.Id)
+                .ToList();
+
+            if (matchedEpisodeIds.Count == 0)
+            {
+                logger.LogWarning("Sonarr series {SeriesId} has no episodes matching {Episode}. Skipping import",
+                    sonarrSeriesId.Value, item.Episode.ToString());
+                return;
+            }
+
+            ManualImportRequest fallbackRequest = new(
                 Path: file.Path,
-                SeriesId: file.Series.Id,
-                EpisodeIds: file.Episodes.Select(e => e.Id).ToList(),
+                SeriesId: sonarrSeriesId.Value,
+                EpisodeIds: matchedEpisodeIds,
                 Quality: file.Quality,
                 Languages: file.Languages,
                 ReleaseGroup: "RUV");
 
-            logger.LogInformation("Importing {Episode} into Sonarr", item.Episode.ToString());
-            await sonarr.ManualImportFilesAsync([request]);
+            logger.LogInformation("Importing {Episode} into Sonarr using fallback episode matching", item.Episode.ToString());
+            await sonarr.ManualImportFilesAsync([fallbackRequest]);
         }
 #pragma warning disable CA1031 // Catch all exceptions to prevent download items from getting stuck in Downloading state
         catch (Exception ex)

--- a/tests/Ruvarr.UnitTests/Jobs/DownloadQueueProcessorTests/SonarrImport.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/DownloadQueueProcessorTests/SonarrImport.cs
@@ -101,6 +101,11 @@ public sealed class SonarrImport : IDisposable
         await sut.Execute(_context);
 
         // Assert
+        await _sonarr.Received(1).GetManualImportsAsync(
+            Arg.Any<string>(),
+            null,
+            Arg.Any<CancellationToken>());
+
         int[] expectedEpisodeIds = [101];
         await _sonarr.Received(1).ManualImportFilesAsync(
             Arg.Is<IEnumerable<ManualImportRequest>>(reqs =>
@@ -110,7 +115,7 @@ public sealed class SonarrImport : IDisposable
     }
 
     [Fact]
-    public async Task SkipsImport_WhenSeriesIsNull()
+    public async Task SkipsImport_WhenSeriesIsNullAndSonarrSeriesIdIsNull()
     {
         // Arrange
         using RuvarrDbContext dbContext = CreateDbContext();
@@ -120,6 +125,8 @@ public sealed class SonarrImport : IDisposable
             seriesId: null,
             episodeIds: [101]);
 
+        _sonarr.GetSeriesAsync(Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Series>());
         _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns([file]);
 
@@ -129,6 +136,9 @@ public sealed class SonarrImport : IDisposable
         await sut.Execute(_context);
 
         // Assert
+        await _sonarr.DidNotReceive().GetEpisodesAsync(
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
         await _sonarr.DidNotReceive().ManualImportFilesAsync(
             Arg.Any<IEnumerable<ManualImportRequest>>(),
             Arg.Any<CancellationToken>());
@@ -158,6 +168,164 @@ public sealed class SonarrImport : IDisposable
             Arg.Any<IEnumerable<ManualImportRequest>>(),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task ImportsEpisode_WhenSeriesIsNullButSonarrSeriesIdKnown()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        await SeedMatchedEpisodeAsync(dbContext);
+
+        ManualImportFile file = CreateManualImportFile(
+            seriesId: null,
+            episodeIds: []);
+
+        Series sonarrSeries = CreateSonarrSeries(id: 42, tvdbId: 5000);
+        _sonarr.GetSeriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { sonarrSeries });
+        _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns([file]);
+        _sonarr.GetEpisodesAsync(42, Arg.Any<CancellationToken>())
+            .Returns(new[] { new SonarrEpisode(Id: 201, SeriesId: 42, SeasonNumber: 1, EpisodeNumber: 1) });
+
+        DownloadQueueProcessor sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        int[] expectedEpisodeIds = [201];
+        await _sonarr.Received(1).ManualImportFilesAsync(
+            Arg.Is<IEnumerable<ManualImportRequest>>(reqs =>
+                reqs.First().SeriesId == 42 &&
+                reqs.First().EpisodeIds.SequenceEqual(expectedEpisodeIds)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SkipsImport_WhenSeriesIsNullAndNoEpisodesMatch()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        await SeedMatchedEpisodeAsync(dbContext);
+
+        ManualImportFile file = CreateManualImportFile(
+            seriesId: null,
+            episodeIds: []);
+
+        Series sonarrSeries = CreateSonarrSeries(id: 42, tvdbId: 5000);
+        _sonarr.GetSeriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { sonarrSeries });
+        _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns([file]);
+        _sonarr.GetEpisodesAsync(42, Arg.Any<CancellationToken>())
+            .Returns(new[] { new SonarrEpisode(Id: 201, SeriesId: 42, SeasonNumber: 99, EpisodeNumber: 99) });
+
+        DownloadQueueProcessor sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        await _sonarr.DidNotReceive().ManualImportFilesAsync(
+            Arg.Any<IEnumerable<ManualImportRequest>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ImportsEpisode_WithMultipleEpisodes_WhenSeriesIsNull()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        await SeedMatchedEpisodeWithMultipleTvdbEpisodesAsync(dbContext);
+
+        ManualImportFile file = CreateManualImportFile(
+            seriesId: null,
+            episodeIds: [],
+            filename: "Test.series.S01E01E02-RUV.mp4");
+
+        Series sonarrSeries = CreateSonarrSeries(id: 42, tvdbId: 5000);
+        _sonarr.GetSeriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { sonarrSeries });
+        _sonarr.GetManualImportsAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns([file]);
+        _sonarr.GetEpisodesAsync(42, Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new SonarrEpisode(Id: 201, SeriesId: 42, SeasonNumber: 1, EpisodeNumber: 1),
+                new SonarrEpisode(Id: 202, SeriesId: 42, SeasonNumber: 1, EpisodeNumber: 2),
+                new SonarrEpisode(Id: 203, SeriesId: 42, SeasonNumber: 2, EpisodeNumber: 1),
+            });
+
+        DownloadQueueProcessor sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(_context);
+
+        // Assert
+        int[] expectedEpisodeIds = [201, 202];
+        await _sonarr.Received(1).ManualImportFilesAsync(
+            Arg.Is<IEnumerable<ManualImportRequest>>(reqs =>
+                reqs.First().SeriesId == 42 &&
+                reqs.First().EpisodeIds.SequenceEqual(expectedEpisodeIds)),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static async Task<DownloadQueueItem> SeedMatchedEpisodeWithMultipleTvdbEpisodesAsync(RuvarrDbContext dbContext)
+    {
+        TvdbSeries series = new TvdbSeriesBuilder().WithId(5000).Build();
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).Build();
+        program.TryAddEpisode("ep0001", new Uri("http://test.com/stream"), "Episode 1", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.MatchTvdb(series);
+        RuvEpisode episode = program.Episodes[0];
+        episode.MatchMultiple([
+            TvdbEpisode.Create(tvdbId: 5001, seasonNumber: 1, episodeNumber: 1, isMissing: true),
+            TvdbEpisode.Create(tvdbId: 5002, seasonNumber: 1, episodeNumber: 2, isMissing: true),
+        ]);
+        dbContext.Set<RuvProgram>().Add(program);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        DownloadQueueItem item = DownloadQueueItem.Create(episode);
+        dbContext.Set<DownloadQueueItem>().Add(item);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return item;
+    }
+
+    private static Series CreateSonarrSeries(int id, int tvdbId) => new(
+        Title: "Test Series",
+        SortTitle: "test series",
+        Status: "continuing",
+        Ended: false,
+        Overview: "",
+        Airtime: new TimeOnly(20, 0),
+        Originallanguage: new Originallanguage(1, "English"),
+        Year: 2024,
+        Path: "/tv/test",
+        QualityProfileId: 1,
+        SeasonFolder: true,
+        Monitored: true,
+        MonitorNewItems: "all",
+        UseScheneNumbering: false,
+        Runtime: 30,
+        TvdbId: tvdbId,
+        TvRageId: 0,
+        TvMazeId: 0,
+        TmdbId: 0,
+        SeriesType: "standard",
+        CleanTitle: "testseries",
+        ImdbId: "",
+        TitleSlug: "test-series",
+        Certification: "",
+        FirstAired: DateTime.UtcNow,
+        LastAired: DateTime.UtcNow,
+        Added: DateTime.UtcNow,
+        Images: [],
+        Seasons: [],
+        Genres: [],
+        Ratings: new Ratings(0, 0),
+        LanguageProfileId: 1,
+        Id: id);
 
     private ManualImportFile CreateManualImportFile(
         int? seriesId,


### PR DESCRIPTION
## Summary

- Removes `seriesId` from `GetManualImportsAsync` call — when Sonarr receives a `seriesId`, it ignores the `folder` parameter and returns library files instead of scanning the download folder, causing `.First()` to throw
- Adds `GetEpisodesAsync(int seriesId)` to `ISonarrClient` / `SonarrClient` / `CachingSonarrClient` calling `api/v3/episode?seriesId={id}`
- When Sonarr can't auto-match a file to a series (e.g. filename is "Karsten og Petra" but Sonarr has the series as "Casper and Emma"), falls back to fetching episodes for the known `sonarrSeriesId` and matching by season/episode number

## Root cause

`Andri og Edda II` is matched to TVDB 275562 ("Karsten og Petra"), which Sonarr tracks as "Casper and Emma". Files downloaded as `Karsten.og.Petra.S03EXX-RUV.mp4` were never returned by Sonarr's manual import API when `seriesId` was passed, because Sonarr switched to scanning its own library path rather than the download folder.

## Test plan

- Updated `ImportsEpisode_WhenSeriesExistsInSonarr` — asserts `GetManualImportsAsync` called with `null` seriesId
- Updated `SkipsImport_WhenSeriesIsNullAndSonarrSeriesIdIsNull` — verifies `GetEpisodesAsync` not called when no series match
- Added `ImportsEpisode_WhenSeriesIsNullButSonarrSeriesIdKnown` — fallback path succeeds
- Added `SkipsImport_WhenSeriesIsNullAndNoEpisodesMatch` — fallback path skips gracefully
- Added `ImportsEpisode_WithMultipleEpisodes_WhenSeriesIsNull` — all matched episode IDs included