### PR TITLE
feat: continue syncing known programs after they leave the featured feed

### DIFF
--- a/src/Ruvarr/Jobs/RuvProgramRefreshJob.cs
+++ b/src/Ruvarr/Jobs/RuvProgramRefreshJob.cs
@@ -35,6 +35,8 @@ internal sealed class RuvProgramRefreshJob(
             return;
         }
 
+        HashSet<int> apiRuvIds = [.. programs.Select(x => x.Id)];
+
         List<RuvProgram> existingTvPrograms = await SyncPrograms(programs);
 
         UpdateExistingProgramMetadata(existingTvPrograms, programs);
@@ -42,6 +44,8 @@ internal sealed class RuvProgramRefreshJob(
         await dbContext.SaveChangesAsync();
 
         EnqueueProgramRefreshes(programs);
+
+        await EnqueueKnownProgramRefreshes(apiRuvIds);
 
         await EnqueueUnmatchedProgramsForLookup();
 
@@ -119,6 +123,7 @@ internal sealed class RuvProgramRefreshJob(
 
         Dictionary<int, Uri?> imageByRuvId = programs.ToDictionary(x => x.Id, x => x.Image);
         Dictionary<int, string?> descriptionByRuvId = programs.ToDictionary(x => x.Id, x => JoinDescription(x.Description));
+        Dictionary<int, bool> multipleEpisodesByRuvId = programs.ToDictionary(x => x.Id, x => x.MultipleEpisodes);
 
         foreach (RuvProgram existing in existingTvPrograms)
         {
@@ -137,6 +142,11 @@ internal sealed class RuvProgramRefreshJob(
             {
                 existing.UpdateDescription(incomingDescription);
             }
+
+            if (multipleEpisodesByRuvId.TryGetValue(existing.RuvId, out bool incomingMultipleEpisodes))
+            {
+                existing.UpdateHasMultipleEpisodes(incomingMultipleEpisodes);
+            }
         }
     }
 
@@ -150,6 +160,22 @@ internal sealed class RuvProgramRefreshJob(
         {
             syncQueue.Enqueue(program.Id, program.Title);
         }
+        broadcaster.Publish(new QueueChangedEvent<ProgramRefreshQueueItemSummary>());
+    }
+
+    private async Task EnqueueKnownProgramRefreshes(HashSet<int> apiRuvIds)
+    {
+        List<RuvProgram> knownPrograms = await dbContext.Set<RuvProgram>()
+            .IgnoreAutoIncludes()
+            .Where(x => x.HasMultipleEpisodes)
+            .Where(x => !apiRuvIds.Contains(x.RuvId))
+            .ToListAsync();
+
+        foreach (RuvProgram program in knownPrograms)
+        {
+            syncQueue.Enqueue(program.RuvId, program.Name);
+        }
+
         broadcaster.Publish(new QueueChangedEvent<ProgramRefreshQueueItemSummary>());
     }
 

--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -31,7 +31,7 @@ internal sealed partial class RuvProgram
 
     public required string? ForeignName { get; init; }
 
-    public required bool HasMultipleEpisodes { get; init; }
+    public bool HasMultipleEpisodes { get; private set; }
 
     public required DateTime Created { get; init; }
 
@@ -125,6 +125,16 @@ internal sealed partial class RuvProgram
 
     private static string? SanitizeSlug(string? slug) =>
         slug is not null && SlugPattern.IsMatch(slug) ? slug : null;
+
+    public void UpdateHasMultipleEpisodes(bool value)
+    {
+        if (HasMultipleEpisodes == value)
+        {
+            return;
+        }
+
+        HasMultipleEpisodes = value;
+    }
 
     public void SetMonitoredStatus(bool monitored)
     {

--- a/tests/Ruvarr.UnitTests/Jobs/RuvProgramRefreshJobTests/KnownProgramRefreshEnqueue.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/RuvProgramRefreshJobTests/KnownProgramRefreshEnqueue.cs
@@ -1,0 +1,171 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Infrastructure.Ruv;
+using Ruvarr.Infrastructure.Ruv.Models;
+using Ruvarr.Jobs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
+using Ruvarr.Programs.Domain;
+using Ruvarr.Settings;
+using Ruvarr.TvdbSeriesLookup.Notifiers;
+using Ruvarr.Testing.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Jobs.RuvProgramRefreshJobTests;
+
+public sealed class KnownProgramRefreshEnqueue
+{
+    private readonly IRuvClient _ruv = Substitute.For<IRuvClient>();
+    private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
+    private readonly ProgramRefreshNotifier _syncQueue = new();
+    private readonly TvdbSeriesLookupNotifier _tvdbLookupQueue = new();
+    private readonly ISettingsStore _settingsStore = Substitute.For<ISettingsStore>();
+
+    public KnownProgramRefreshEnqueue()
+    {
+        _serviceProvider.GetService(Arg.Any<Type>()).Returns(Array.Empty<object>());
+        _settingsStore.Current.Returns(new RuvarrSettings { IgnoredChannels = [] });
+    }
+
+    private RuvarrDbContext CreateDbContext() => new(
+        new DbContextOptionsBuilder<RuvarrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options,
+        _serviceProvider);
+
+    private RuvProgramRefreshJob CreateJob(RuvarrDbContext dbContext) => new(
+        NullLogger<RuvProgramRefreshJob>.Instance,
+        _ruv,
+        dbContext,
+        _settingsStore,
+        _syncQueue,
+        _tvdbLookupQueue,
+        new DomainEventBroadcaster());
+
+    private static RuvTvProgram CreateRuvTvProgram(int id, bool multipleEpisodes = true) => new(
+        LastUpdated: DateTimeOffset.UtcNow,
+        Id: id,
+        Title: $"Program {id}",
+        ForeignTitle: $"Foreign Program {id}",
+        Slug: $"program-{id}",
+        ImageRenditions: new RuvImageRenditions([]),
+        Image: new Uri("http://example.com/image.jpg"),
+        ImageOg: new Uri("http://example.com/image-og.jpg"),
+        PortraitImageRenditions: new RuvPortraitImageRenditions([]),
+        PortraitImage: new Uri("http://example.com/portrait.jpg"),
+        Description: [],
+        Format: "format",
+        Categories: [],
+        Division: "division",
+        MultipleEpisodes: multipleEpisodes,
+        Episodes: [],
+        ReverseEpisodeOrder: false,
+        WebAvailableEpisodes: 1,
+        VodAvailableEpisodes: 0,
+        PodcastVailableEpisodes: 0,
+        WebLatestDate: DateTime.UtcNow,
+        Channel: "ruv",
+        WebPlayerUrl: new Uri("http://example.com/player"));
+
+    [Fact]
+    public async Task EnqueuesDbProgram_NotInApiResponse_WhenHasMultipleEpisodesIsTrue()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram knownProgram = new RuvProgramBuilder().WithRuvId(99).WithName("Known Show").WithMultipleEpisodes().Build();
+        dbContext.Set<RuvProgram>().Add(knownProgram);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        RuvFeaturedTv featured = new(DateTimeOffset.UtcNow,
+            [new RuvPanel(DateTimeOffset.UtcNow, "Panel", "panel", "type", "style",
+                [CreateRuvTvProgram(id: 1)])]);
+        _ruv.GetFeaturedTv(Arg.Any<CancellationToken>()).Returns(featured);
+        _ruv.GetKidsTvAsync(Arg.Any<CancellationToken>()).Returns((RuvFeaturedTv?)null);
+
+        RuvProgramRefreshJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        _syncQueue.Items.ShouldContain(x => x.RuvId == 99);
+    }
+
+    [Fact]
+    public async Task DoesNotDoubleEnqueue_WhenProgramIsInApiResponse()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram existingProgram = new RuvProgramBuilder().WithRuvId(1).WithMultipleEpisodes().Build();
+        dbContext.Set<RuvProgram>().Add(existingProgram);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        RuvFeaturedTv featured = new(DateTimeOffset.UtcNow,
+            [new RuvPanel(DateTimeOffset.UtcNow, "Panel", "panel", "type", "style",
+                [CreateRuvTvProgram(id: 1)])]);
+        _ruv.GetFeaturedTv(Arg.Any<CancellationToken>()).Returns(featured);
+        _ruv.GetKidsTvAsync(Arg.Any<CancellationToken>()).Returns((RuvFeaturedTv?)null);
+
+        RuvProgramRefreshJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert — program 1 should appear exactly once in the queue
+        _syncQueue.Items.Count(x => x.RuvId == 1).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task SkipsPrograms_WhenHasMultipleEpisodesIsFalse()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram singleEpisodeProgram = new RuvProgramBuilder().WithRuvId(99).WithName("Single Episode").WithMultipleEpisodes(false).Build();
+        dbContext.Set<RuvProgram>().Add(singleEpisodeProgram);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        RuvFeaturedTv featured = new(DateTimeOffset.UtcNow,
+            [new RuvPanel(DateTimeOffset.UtcNow, "Panel", "panel", "type", "style",
+                [CreateRuvTvProgram(id: 1)])]);
+        _ruv.GetFeaturedTv(Arg.Any<CancellationToken>()).Returns(featured);
+        _ruv.GetKidsTvAsync(Arg.Any<CancellationToken>()).Returns((RuvFeaturedTv?)null);
+
+        RuvProgramRefreshJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        _syncQueue.Items.ShouldNotContain(x => x.RuvId == 99);
+    }
+
+    [Fact]
+    public async Task EnqueuesMultipleKnownPrograms()
+    {
+        // Arrange
+        using RuvarrDbContext dbContext = CreateDbContext();
+        RuvProgram known1 = new RuvProgramBuilder().WithRuvId(90).WithName("Known A").WithMultipleEpisodes().Build();
+        RuvProgram known2 = new RuvProgramBuilder().WithRuvId(91).WithName("Known B").WithMultipleEpisodes().Build();
+        dbContext.Set<RuvProgram>().AddRange(known1, known2);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        RuvFeaturedTv featured = new(DateTimeOffset.UtcNow,
+            [new RuvPanel(DateTimeOffset.UtcNow, "Panel", "panel", "type", "style",
+                [CreateRuvTvProgram(id: 1)])]);
+        _ruv.GetFeaturedTv(Arg.Any<CancellationToken>()).Returns(featured);
+        _ruv.GetKidsTvAsync(Arg.Any<CancellationToken>()).Returns((RuvFeaturedTv?)null);
+
+        RuvProgramRefreshJob sut = CreateJob(dbContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        _syncQueue.Items.ShouldContain(x => x.RuvId == 90);
+        _syncQueue.Items.ShouldContain(x => x.RuvId == 91);
+    }
+}

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/UpdateHasMultipleEpisodes.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/UpdateHasMultipleEpisodes.cs
@@ -1,0 +1,50 @@
+using Ruvarr.Programs.Domain;
+using Ruvarr.Testing.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.Domain.RuvProgramTests;
+
+public sealed class UpdateHasMultipleEpisodes
+{
+    [Fact]
+    public void UpdatesFromFalseToTrue()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().WithMultipleEpisodes(false).Build();
+
+        // Act
+        sut.UpdateHasMultipleEpisodes(true);
+
+        // Assert
+        sut.HasMultipleEpisodes.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void UpdatesFromTrueToFalse()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().WithMultipleEpisodes(true).Build();
+
+        // Act
+        sut.UpdateHasMultipleEpisodes(false);
+
+        // Assert
+        sut.HasMultipleEpisodes.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DoesNothing_WhenValueIsSame()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().WithMultipleEpisodes(true).Build();
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.UpdateHasMultipleEpisodes(true);
+
+        // Assert
+        sut.HasMultipleEpisodes.ShouldBeTrue();
+        sut.DomainEvents.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- Programs that fall off the RÚV featured/kids API panels were never re-synced, leaving stale episode data in the DB indefinitely
- `RuvProgramRefreshJob` now also enqueues all programs already in the DB with `HasMultipleEpisodes = true` that are absent from the current API response
- These programs flow through the existing `RuvEpisodesSyncJob`, which calls `/api/programs/program/{id}/all`, trims removed episodes, and deletes the program entirely if the API returns null
- `HasMultipleEpisodes` is now updated on existing programs during each refresh cycle so the flag stays in sync with the API

## Test plan
- [x] New `KnownProgramRefreshEnqueue` tests: enqueues DB-only programs, skips single-episode programs, no double-enqueue for programs already in API response
- [x] New `UpdateHasMultipleEpisodes` domain tests: update from false→true, no-op when unchanged
- [x] `dotnet test` — all 950 tests pass