### PR TITLE
fix: suppress unpatched transitive SQLite native advisory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,15 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <!--
+      Transitive SQLite native bundle (via Microsoft.EntityFrameworkCore.Sqlite). GHSA-2m69-gcr7-jv3q
+      affects SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11 with no patched 2.x release; the fix lives only in the
+      3.x line, which EF Core 10 does not yet consume. Ruvarr uses SQLite as a local embedded store with no
+      untrusted SQL surface, so the practical risk is low. Remove this suppression once EF Core ships 3.x.
+    -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />


### PR DESCRIPTION
## Summary

A newly published advisory broke the build on **every** branch. `dotnet restore` fails the `NU1903` audit, and `TreatWarningsAsErrors=true` turns it into an error.

- **Advisory:** [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) (high) — `SQLitePCLRaw.lib.e_sqlite3` has a vulnerable bundled SQLite.
- **Affected:** `<= 2.1.11`, **patched: none** in the 2.x line. The fix exists only in the `3.x` family, which EF Core 10 does not yet consume (confirmed: Dependabot's EF 10.0.9 bump still ships 2.1.11).
- **Pulled transitively** via `Microsoft.EntityFrameworkCore.Sqlite`.

## Fix

Add a `NuGetAuditSuppress` entry for this advisory in `Directory.Packages.props`, with a comment documenting the rationale and removal condition.

Justification: no patched 2.x release exists, and Ruvarr uses SQLite as a local embedded store with no untrusted SQL surface, so practical risk is low. Suppression is removed once EF Core consumes SQLitePCLRaw 3.x.

## Test plan

- [x] `dotnet restore Ruvarr.slnx` succeeds (was failing)
- [x] `dotnet build Ruvarr.slnx` — 0 warnings, 0 errors