### PR TITLE
fix(tvdb-lookup): compare season count against total program episodes

### DIFF
--- a/src/Ruvarr/TvdbEpisodeLookup/Strategies/EpisodeNumberMatchingStrategy.cs
+++ b/src/Ruvarr/TvdbEpisodeLookup/Strategies/EpisodeNumberMatchingStrategy.cs
@@ -19,7 +19,7 @@ internal sealed class EpisodeNumberMatchingStrategy(
             {
                 List<Episode> tvdbSeasonEpisodes = [.. context.SeriesData.Episodes.Where(x => x.SeasonNumber == season)];
 
-                if (tvdbSeasonEpisodes.Count == unmatchedEpisodes.Count)
+                if (tvdbSeasonEpisodes.Count == context.Program.Episodes.Count)
                 {
                     foreach (RuvEpisode unmatchedEpisode in unmatchedEpisodes)
                     {

--- a/tests/Ruvarr.UnitTests/TvdbEpisodeLookup/Strategies/EpisodeNumberMatchingStrategyTests.cs
+++ b/tests/Ruvarr.UnitTests/TvdbEpisodeLookup/Strategies/EpisodeNumberMatchingStrategyTests.cs
@@ -106,15 +106,15 @@ public sealed class EpisodeNumberMatchingStrategyTests
     {
         // Arrange
         RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithName("Show II").Build();
-        program.TryAddEpisode("ep0001", new Uri("http://test.com"), "Þáttur 1", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("ep0001", new Uri("http://test.com"), "þáttur 1", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
         program.TryAddEpisode("ep0002", new Uri("http://test.com"), "þáttur 2", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
         program.MatchTvdb(new TvdbSeriesBuilder().WithId(1000).Build());
-        program.Episodes[0].Match(101, 1, 1, false);
+        program.Episodes[0].Match(201, 2, 1, false);
 
-        Episode tvdbEpisode202 = new TvdbEpisodeDataBuilder()
-            .WithId(202).WithSeasonNumber(2).WithNumber(2).Build();
+        Episode tvdbEpisode201 = new TvdbEpisodeDataBuilder().WithId(201).WithSeasonNumber(2).WithNumber(1).Build();
+        Episode tvdbEpisode202 = new TvdbEpisodeDataBuilder().WithId(202).WithSeasonNumber(2).WithNumber(2).Build();
         SeriesData seriesData = new TvdbSeriesDataBuilder()
-            .WithId(1000).WithEpisodes(tvdbEpisode202).Build();
+            .WithId(1000).WithEpisodes(tvdbEpisode201, tvdbEpisode202).Build();
 
         EpisodeMatchingContext context = new(program, seriesData, []);
         EpisodeNumberMatchingStrategy sut = CreateSut();
@@ -123,6 +123,7 @@ public sealed class EpisodeNumberMatchingStrategyTests
         await sut.MatchAsync(context, CancellationToken.None);
 
         // Assert
+        program.Episodes[0].TvdbEpisodes[0].TvdbId.ShouldBe(201);
         program.Episodes[1].TvdbEpisodes[0].TvdbId.ShouldBe(202);
     }
 
@@ -170,5 +171,44 @@ public sealed class EpisodeNumberMatchingStrategyTests
         // Assert
         program.Episodes[0].TvdbEpisodes[0].TvdbId.ShouldBe(201);
         program.Episodes[0].TvdbEpisodes[0].SeasonNumber.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task WhenSomeEpisodesAlreadyMatched_RemainingEpisodesMatchByNumber()
+    {
+        // Arrange
+        RuvProgram program = new RuvProgramBuilder().WithRuvId(1).WithName("Show II").Build();
+        program.TryAddEpisode("ep0001", new Uri("http://test.com"), "þáttur 1", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("ep0002", new Uri("http://test.com"), "þáttur 2", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("ep0003", new Uri("http://test.com"), "þáttur 3", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("ep0004", new Uri("http://test.com"), "þáttur 4", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("ep0005", new Uri("http://test.com"), "þáttur 5", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.TryAddEpisode("ep0006", new Uri("http://test.com"), "þáttur 6", "", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+        program.MatchTvdb(new TvdbSeriesBuilder().WithId(1000).Build());
+        program.Episodes[0].Match(201, 2, 1, false);
+        program.Episodes[1].Match(202, 2, 2, false);
+        program.Episodes[2].Match(203, 2, 3, false);
+        program.Episodes[3].Match(204, 2, 4, false);
+
+        Episode tvdbEpisode1 = new TvdbEpisodeDataBuilder().WithId(201).WithSeasonNumber(2).WithNumber(1).Build();
+        Episode tvdbEpisode2 = new TvdbEpisodeDataBuilder().WithId(202).WithSeasonNumber(2).WithNumber(2).Build();
+        Episode tvdbEpisode3 = new TvdbEpisodeDataBuilder().WithId(203).WithSeasonNumber(2).WithNumber(3).Build();
+        Episode tvdbEpisode4 = new TvdbEpisodeDataBuilder().WithId(204).WithSeasonNumber(2).WithNumber(4).Build();
+        Episode tvdbEpisode5 = new TvdbEpisodeDataBuilder().WithId(205).WithSeasonNumber(2).WithNumber(5).Build();
+        Episode tvdbEpisode6 = new TvdbEpisodeDataBuilder().WithId(206).WithSeasonNumber(2).WithNumber(6).Build();
+        SeriesData seriesData = new TvdbSeriesDataBuilder()
+            .WithId(1000)
+            .WithEpisodes(tvdbEpisode1, tvdbEpisode2, tvdbEpisode3, tvdbEpisode4, tvdbEpisode5, tvdbEpisode6)
+            .Build();
+
+        EpisodeMatchingContext context = new(program, seriesData, []);
+        EpisodeNumberMatchingStrategy sut = CreateSut();
+
+        // Act
+        await sut.MatchAsync(context, CancellationToken.None);
+
+        // Assert
+        program.Episodes[4].TvdbEpisodes[0].TvdbId.ShouldBe(205);
+        program.Episodes[5].TvdbEpisodes[0].TvdbId.ShouldBe(206);
     }
 }

--- a/tests/Ruvarr.UnitTests/TvdbEpisodeLookup/Strategies/EpisodeNumberMatchingStrategyTests.cs
+++ b/tests/Ruvarr.UnitTests/TvdbEpisodeLookup/Strategies/EpisodeNumberMatchingStrategyTests.cs
@@ -208,6 +208,10 @@ public sealed class EpisodeNumberMatchingStrategyTests
         await sut.MatchAsync(context, CancellationToken.None);
 
         // Assert
+        program.Episodes[0].TvdbEpisodes[0].TvdbId.ShouldBe(201);
+        program.Episodes[1].TvdbEpisodes[0].TvdbId.ShouldBe(202);
+        program.Episodes[2].TvdbEpisodes[0].TvdbId.ShouldBe(203);
+        program.Episodes[3].TvdbEpisodes[0].TvdbId.ShouldBe(204);
         program.Episodes[4].TvdbEpisodes[0].TvdbId.ShouldBe(205);
         program.Episodes[5].TvdbEpisodes[0].TvdbId.ShouldBe(206);
     }


### PR DESCRIPTION
## Summary

- Fix guard in `EpisodeNumberMatchingStrategy` that compared TVDB season episode count against `unmatchedEpisodes.Count` instead of `context.Program.Episodes.Count`, preventing partially-matched programs from ever matching their remaining episodes.
- Add regression test for the partial-match scenario (4 matched + 2 unmatched against a full 6-episode TVDB season).
- Assert pre-matched episodes retain their matches in the regression test.

## Test plan

- [x] Regression test `WhenSomeEpisodesAlreadyMatched_RemainingEpisodesMatchByNumber` passes
- [x] Existing test `OnlyProcessesUnmatchedEpisodes` updated and passes with corrected setup
- [x] All 878 unit tests pass

Closes #360