### PR TITLE
fix: program refresh stuck on titleless RÚV episodes

### DIFF
--- a/docs/adr/0001-per-program-unit-of-work-in-episode-sync.md
+++ b/docs/adr/0001-per-program-unit-of-work-in-episode-sync.md
@@ -1,0 +1,21 @@
+# Per-Program Unit of Work in RÚV Episode Sync
+
+## Context
+
+`RuvEpisodesSyncJob` processes a batch of queued programs. The original implementation loaded all programs in a single up-front query, then looped over the in-memory list. A single unhandled exception (e.g., a `SaveChanges` constraint violation from a titleless episode) would abort the entire batch, leaving the in-progress item stuck in **Processing** and abandoning all remaining programs.
+
+## Decision
+
+Replace the single batch query with a lightweight up-front projection (RuvId + Name only, `AsNoTracking`) to determine the sorted work list, then load each program individually via `FindRuvProgramAsync` inside the loop. Each iteration runs inside a `try/catch (Exception)` that calls `ChangeTracker.Clear()`, marks the item complete, and continues to the next program.
+
+This trades one tracked batch load for N per-program tracked loads. The tradeoff is accepted because:
+
+- Fault isolation requires that each program's dirty state (tracked mutations + pending inserts) never carries over into another program's `SaveChanges`. A shared tracked batch load makes this impossible without manual detach bookkeeping.
+- `ChangeTracker.Clear()` is the idiomatic EF Core way to discard all tracked state, but it requires that no other program's state is currently in the tracker — which is only guaranteed when each program is loaded fresh per iteration.
+- The extra DB round-trips (N queries vs. 1) are acceptable: the bottleneck in this job is the RÚV HTTP call per program, not the DB queries.
+
+## Considered Options
+
+**Batch load + manual detach**: Load all programs in one query, then after a failure, call `dbContext.Entry(program).State = EntityState.Detached` for each affected entity. Rejected because it requires tracking which entities are dirty and detaching them precisely — fragile to future mutation additions.
+
+**Separate DbContext per program**: Instantiate a new `DbContext` per iteration via a factory. Rejected because the job receives a single scoped `DbContext` via DI; introducing a factory would require changing the constructor and DI registration, which is a broader change than the scope of this fix.

--- a/src/Ruvarr/Infrastructure/Ruv/Models/RuvTvEpisode.cs
+++ b/src/Ruvarr/Infrastructure/Ruv/Models/RuvTvEpisode.cs
@@ -12,7 +12,7 @@ public sealed record class RuvTvEpisode(
     [property: JsonPropertyName("duration")] int Duration,
     [property: JsonPropertyName("duration_friendly")] string DurationFriendly,
     [property: JsonPropertyName("event")] int Event,
-    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("title")] string? Title,
     [property: JsonPropertyName("slug")] string Slug,
     [property: JsonPropertyName("description")] IReadOnlyList<string> Description,
     [property: JsonPropertyName("image_renditions")] RuvImageRenditions ImageRenditions,

--- a/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
+++ b/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
@@ -122,6 +122,13 @@ internal sealed class RuvEpisodesSyncJob(
                     RuvEpisode newEpisode = program.Episodes.First(ep => ep.RuvId == e.Id);
                     logger.LogInformation("Added RÚV episode {Episode}", newEpisode.ToString());
                 }
+                else if (string.IsNullOrWhiteSpace(e.Title))
+                {
+                    logger.LogInformation(
+                        "Skipping titleless RÚV episode {EpisodeId} for program {ProgramName}",
+                        e.Id,
+                        program.Name);
+                }
             }
 
             logger.LogDebug("Removing episodes from RÚV program '{Name}'", program.Name);

--- a/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
+++ b/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
@@ -59,8 +59,8 @@ internal sealed class RuvEpisodesSyncJob(
             missingTvdbIds = await sonarr.GetMissingTvdbIdsAsync(CancellationToken.None);
             sonarrSeries = await sonarr.GetSeriesAsync();
         }
-#pragma warning disable CA1031 // Catch all exceptions to prevent queue items from getting stuck in Processing state
-        catch (Exception ex)
+#pragma warning disable CA1031 // Catch all non-cancellation exceptions to prevent queue items from getting stuck in Processing state
+        catch (Exception ex) when (ex is not OperationCanceledException)
 #pragma warning restore CA1031
         {
             logger.LogError(ex, "Sonarr calls failed during RÚV episode sync");
@@ -103,8 +103,8 @@ internal sealed class RuvEpisodesSyncJob(
                     monitoredTvdbIds,
                     missingEpisodesTvdbIds);
             }
-#pragma warning disable CA1031 // Catch all exceptions to prevent queue items from getting stuck in Processing state
-            catch (Exception ex)
+#pragma warning disable CA1031 // Catch all non-cancellation exceptions to prevent queue items from getting stuck in Processing state
+            catch (Exception ex) when (ex is not OperationCanceledException)
 #pragma warning restore CA1031
             {
                 logger.LogError(

--- a/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
+++ b/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
@@ -171,14 +171,14 @@ internal sealed class RuvEpisodesSyncJob(
             if (added)
             {
                 RuvEpisode newEpisode = program.Episodes.First(ep => ep.RuvId == e.Id);
-                logger.LogInformation("Added RÚV episode {Episode}", newEpisode.ToString());
+                logger.LogInformation("Added RÚV episode {Episode}", StripNewlines(newEpisode.ToString()));
             }
             else if (string.IsNullOrWhiteSpace(e.Title))
             {
                 logger.LogInformation(
                     "Skipping titleless RÚV episode {EpisodeId} for program {ProgramName}",
-                    e.Id,
-                    programName);
+                    StripNewlines(e.Id),
+                    StripNewlines(programName));
             }
         }
 
@@ -189,7 +189,7 @@ internal sealed class RuvEpisodesSyncJob(
 
         foreach (RuvEpisode episode in removed)
         {
-            logger.LogInformation("Removed RÚV episode {Episode}", episode.ToString());
+            logger.LogInformation("Removed RÚV episode {Episode}", StripNewlines(episode.ToString()));
             program.RemoveEpisode(episode);
         }
 
@@ -208,4 +208,8 @@ internal sealed class RuvEpisodesSyncJob(
 
         await dbContext.SaveChangesAsync();
     }
+
+    private static string StripNewlines(string? value) =>
+        value?.Replace("\r", string.Empty, StringComparison.Ordinal)
+              .Replace("\n", string.Empty, StringComparison.Ordinal) ?? string.Empty;
 }

--- a/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
+++ b/src/Ruvarr/Jobs/RuvEpisodesSyncJob.cs
@@ -44,11 +44,11 @@ internal sealed class RuvEpisodesSyncJob(
             return;
         }
 
-        List<RuvProgram> programs = await dbContext.Set<RuvProgram>()
-            .Include(x => x.Episodes)
-                .ThenInclude(x => x.TvdbEpisodes)
+        var programs = await dbContext.Set<RuvProgram>()
+            .AsNoTracking()
             .Where(x => ruvIds.Contains(x.RuvId))
             .Where(x => x.HasMultipleEpisodes)
+            .Select(x => new { x.RuvId, x.Name })
             .ToListAsync();
 
         HashSet<int> missingTvdbIds;
@@ -87,76 +87,39 @@ internal sealed class RuvEpisodesSyncJob(
 
         HashSet<int> loadedIds = [.. programs.Select(p => p.RuvId)];
 
-        foreach (RuvProgram program in programs)
+        foreach (var projection in programs)
         {
-            syncQueue.MarkProcessing(program.RuvId);
+            int ruvId = projection.RuvId;
+            string programName = projection.Name;
 
-            logger.LogDebug("Getting episodes for RÚV program '{Name}'", program.Name);
+            syncQueue.MarkProcessing(ruvId);
 
-            RuvTvProgram? ruvProgram = await ruv.GetProgramAsync(program.RuvId);
-
-            if (ruvProgram is null)
+            try
             {
-                logger.LogInformation("Deleting RÚV program {Name} and {Count} episodes", program.Name, program.Episodes.Count);
-                dbContext.Set<RuvProgram>().Remove(program);
-                await dbContext.SaveChangesAsync();
-                syncQueue.MarkComplete(program.RuvId);
+                await ProcessProgramAsync(
+                    ruvId,
+                    programName,
+                    missingTvdbIds,
+                    monitoredTvdbIds,
+                    missingEpisodesTvdbIds);
+            }
+#pragma warning disable CA1031 // Catch all exceptions to prevent queue items from getting stuck in Processing state
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                logger.LogError(
+                    ex,
+                    "Failed to process RÚV program '{ProgramName}' (RuvId: {RuvId}); skipping to next",
+                    programName,
+                    ruvId);
+
+                dbContext.ChangeTracker.Clear();
+                syncQueue.MarkComplete(ruvId);
                 broadcaster.Publish(new QueueChangedEvent<ProgramRefreshQueueItemSummary>());
                 continue;
             }
 
-            logger.LogDebug("Adding episodes to RÚV program '{Name}'", program.Name);
-
-            foreach (RuvTvEpisode e in ruvProgram.Episodes)
-            {
-                bool added = program.TryAddEpisode(
-                    id: e.Id,
-                    uri: e.File,
-                    title: e.Title,
-                    description: e.Description.Count > 0 ? e.Description[0] : string.Empty,
-                    firstRun: e.FirstRun,
-                    duration: TimeSpan.FromSeconds(e.Duration));
-
-                if (added)
-                {
-                    RuvEpisode newEpisode = program.Episodes.First(ep => ep.RuvId == e.Id);
-                    logger.LogInformation("Added RÚV episode {Episode}", newEpisode.ToString());
-                }
-                else if (string.IsNullOrWhiteSpace(e.Title))
-                {
-                    logger.LogInformation(
-                        "Skipping titleless RÚV episode {EpisodeId} for program {ProgramName}",
-                        e.Id,
-                        program.Name);
-                }
-            }
-
-            logger.LogDebug("Removing episodes from RÚV program '{Name}'", program.Name);
-            List<RuvEpisode> removed = program.Episodes
-                .Where(entity => !ruvProgram.Episodes.Select(episodeDto => episodeDto.Id).Contains(entity.RuvId))
-                .ToList();
-
-            foreach (RuvEpisode episode in removed)
-            {
-                logger.LogInformation("Removed RÚV episode {Episode}", episode.ToString());
-                program.RemoveEpisode(episode);
-            }
-
-            foreach (RuvEpisode episode in program.Episodes.Where(x => x.TvdbEpisodes.Count > 0))
-            {
-                episode.UpdateMissingStatus(missingTvdbIds);
-            }
-
-            bool isMonitored = program.Series is not null &&
-                monitoredTvdbIds.Contains(program.Series.TvdbId);
-            program.SetMonitoredStatus(isMonitored);
-
-            bool hasMissingEpisodes = program.Series is not null &&
-                missingEpisodesTvdbIds.Contains(program.Series.TvdbId);
-            program.SetHasMissingEpisodes(hasMissingEpisodes);
-
-            await dbContext.SaveChangesAsync();
-            syncQueue.MarkComplete(program.RuvId);
+            syncQueue.MarkComplete(ruvId);
             broadcaster.Publish(new QueueChangedEvent<ProgramRefreshQueueItemSummary>());
         }
 
@@ -166,5 +129,83 @@ internal sealed class RuvEpisodesSyncJob(
         }
 
         broadcaster.Publish(new QueueChangedEvent<ProgramRefreshQueueItemSummary>());
+    }
+
+    private async Task ProcessProgramAsync(
+        int ruvId,
+        string programName,
+        HashSet<int> missingTvdbIds,
+        HashSet<int> monitoredTvdbIds,
+        HashSet<int> missingEpisodesTvdbIds)
+    {
+        logger.LogDebug("Getting episodes for RÚV program '{Name}'", programName);
+
+        if (await dbContext.FindRuvProgramAsync(ruvId, CancellationToken.None) is not RuvProgram program)
+        {
+            logger.LogDebug("RÚV program {RuvId} not found in database; skipping", ruvId);
+            return;
+        }
+
+        RuvTvProgram? ruvProgram = await ruv.GetProgramAsync(ruvId);
+
+        if (ruvProgram is null)
+        {
+            logger.LogInformation("Deleting RÚV program {Name} and {Count} episodes", programName, program.Episodes.Count);
+            dbContext.Set<RuvProgram>().Remove(program);
+            await dbContext.SaveChangesAsync();
+            return;
+        }
+
+        logger.LogDebug("Adding episodes to RÚV program '{Name}'", programName);
+
+        foreach (RuvTvEpisode e in ruvProgram.Episodes)
+        {
+            bool added = program.TryAddEpisode(
+                id: e.Id,
+                uri: e.File,
+                title: e.Title,
+                description: e.Description.Count > 0 ? e.Description[0] : string.Empty,
+                firstRun: e.FirstRun,
+                duration: TimeSpan.FromSeconds(e.Duration));
+
+            if (added)
+            {
+                RuvEpisode newEpisode = program.Episodes.First(ep => ep.RuvId == e.Id);
+                logger.LogInformation("Added RÚV episode {Episode}", newEpisode.ToString());
+            }
+            else if (string.IsNullOrWhiteSpace(e.Title))
+            {
+                logger.LogInformation(
+                    "Skipping titleless RÚV episode {EpisodeId} for program {ProgramName}",
+                    e.Id,
+                    programName);
+            }
+        }
+
+        logger.LogDebug("Removing episodes from RÚV program '{Name}'", programName);
+        List<RuvEpisode> removed = program.Episodes
+            .Where(entity => !ruvProgram.Episodes.Select(episodeDto => episodeDto.Id).Contains(entity.RuvId))
+            .ToList();
+
+        foreach (RuvEpisode episode in removed)
+        {
+            logger.LogInformation("Removed RÚV episode {Episode}", episode.ToString());
+            program.RemoveEpisode(episode);
+        }
+
+        foreach (RuvEpisode episode in program.Episodes.Where(x => x.TvdbEpisodes.Count > 0))
+        {
+            episode.UpdateMissingStatus(missingTvdbIds);
+        }
+
+        bool isMonitored = program.Series is not null &&
+            monitoredTvdbIds.Contains(program.Series.TvdbId);
+        program.SetMonitoredStatus(isMonitored);
+
+        bool hasMissingEpisodes = program.Series is not null &&
+            missingEpisodesTvdbIds.Contains(program.Series.TvdbId);
+        program.SetHasMissingEpisodes(hasMissingEpisodes);
+
+        await dbContext.SaveChangesAsync();
     }
 }

--- a/src/Ruvarr/Programs/Domain/RuvProgram.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgram.cs
@@ -187,8 +187,13 @@ internal sealed partial class RuvProgram
         NextLookup = LookupSchedule.ComputeNextLookup(LookupCount);
     }
 
-    public bool TryAddEpisode(string id, Uri uri, string title, string description, DateTime firstRun, TimeSpan duration)
+    public bool TryAddEpisode(string id, Uri uri, string? title, string description, DateTime firstRun, TimeSpan duration)
     {
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return false;
+        }
+
         RuvEpisode? existing = _episodes.FirstOrDefault(x => x.RuvId == id);
         if (existing is not null)
         {

--- a/src/Ruvarr/Programs/Domain/RuvProgramDbContextExtensions.cs
+++ b/src/Ruvarr/Programs/Domain/RuvProgramDbContextExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Ruvarr.Programs.Domain;
+
+internal static class RuvProgramDbContextExtensions
+{
+    public static async Task<RuvProgram?> FindRuvProgramAsync(
+        this RuvarrDbContext dbContext,
+        int ruvId,
+        CancellationToken cancellationToken)
+    {
+        return await dbContext.Set<RuvProgram>()
+            .Include(x => x.Episodes)
+                .ThenInclude(x => x.TvdbEpisodes)
+            .FirstOrDefaultAsync(x => x.RuvId == ruvId, cancellationToken);
+    }
+}

--- a/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/PerProgramIsolation.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/PerProgramIsolation.cs
@@ -27,9 +27,9 @@ public sealed class PerProgramIsolation
     private const string GeisliName = "Geisli";
     private const string Program1Name = "Forrit Eitt";
     private const string Program2Name = "Forrit Tvö";
-    private const string TitlelessEpisodeId = "ep-null";
+    private const string TitlelessEpisodeId = "ep-nil";
     private const string ConflictingEpisodeId = "ep-p1x";
-    private const string Program2EpisodeId = "ep-p2-1";
+    private const string Program2EpisodeId = "ep-p21";
 
     private readonly IRuvClient _ruv = Substitute.For<IRuvClient>();
     private readonly ISonarrClient _sonarr = Substitute.For<ISonarrClient>();

--- a/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/PerProgramIsolation.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/PerProgramIsolation.cs
@@ -1,0 +1,288 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Infrastructure.Ruv;
+using Ruvarr.Infrastructure.Ruv.Models;
+using Ruvarr.Infrastructure.Sonarr;
+using Ruvarr.Infrastructure.Sonarr.Models;
+using Ruvarr.Jobs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
+using Ruvarr.Programs.Domain;
+using Ruvarr.Settings;
+using Ruvarr.Testing.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Jobs.RuvEpisodesSyncJobTests;
+
+public sealed class PerProgramIsolation
+{
+    private const int GeisliRuvId = 99;
+    private const int Program1RuvId = 101;
+    private const int Program2RuvId = 102;
+    private const string GeisliName = "Geisli";
+    private const string Program1Name = "Forrit Eitt";
+    private const string Program2Name = "Forrit Tvö";
+    private const string TitlelessEpisodeId = "ep-null";
+    private const string ConflictingEpisodeId = "ep-p1x";
+    private const string Program2EpisodeId = "ep-p2-1";
+
+    private readonly IRuvClient _ruv = Substitute.For<IRuvClient>();
+    private readonly ISonarrClient _sonarr = Substitute.For<ISonarrClient>();
+    private readonly ProgramRefreshNotifier _syncQueue = new();
+    private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
+    private readonly ISettingsStore _settingsStore = Substitute.For<ISettingsStore>();
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.db");
+
+    public PerProgramIsolation()
+    {
+        _serviceProvider.GetService(Arg.Any<Type>()).Returns(Array.Empty<object>());
+        _settingsStore.Current.Returns(new RuvarrSettings(
+            SonarrBaseAddress: "http://sonarr", SonarrApiKey: "key"));
+        _sonarr.GetSeriesAsync(Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Series>());
+        _sonarr.GetMissingEpisodesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MissingEpisode>());
+    }
+
+    private RuvarrDbContext CreateDbContext() => new(
+        new DbContextOptionsBuilder<RuvarrDbContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .UseSnakeCaseNamingConvention()
+            .Options,
+        _serviceProvider);
+
+    private RuvEpisodesSyncJob CreateJob(RuvarrDbContext dbContext) => new(
+        NullLogger<RuvEpisodesSyncJob>.Instance,
+        _ruv, dbContext, _sonarr, _syncQueue, new DomainEventBroadcaster(), _settingsStore);
+
+    [Fact]
+    public async Task WhenSingleTitlelessEpisode_ProgramRefreshesCleanlyWithZeroEpisodes()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        using (RuvarrDbContext seedContext = CreateDbContext())
+        {
+            await seedContext.Database.EnsureCreatedAsync(cancellationToken);
+
+            RuvProgram program = new RuvProgramBuilder()
+                .WithRuvId(GeisliRuvId)
+                .WithName(GeisliName)
+                .WithMultipleEpisodes()
+                .Build();
+
+            seedContext.Set<RuvProgram>().Add(program);
+            await seedContext.SaveChangesAsync(cancellationToken);
+        }
+
+        RuvTvEpisode titlelessEpisode = CreateRuvTvEpisode(TitlelessEpisodeId, title: null);
+        RuvTvProgram apiResponse = CreateRuvTvProgram(GeisliRuvId, GeisliName, episodes: [titlelessEpisode]);
+
+        _ruv.GetProgramAsync(GeisliRuvId, Arg.Any<CancellationToken>())
+            .Returns(apiResponse);
+
+        _syncQueue.Enqueue(GeisliRuvId, GeisliName);
+
+        using RuvarrDbContext actContext = CreateDbContext();
+        RuvEpisodesSyncJob sut = CreateJob(actContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        _syncQueue.Items.ShouldBeEmpty();
+
+        using RuvarrDbContext assertContext = CreateDbContext();
+        List<RuvEpisode> episodes = await assertContext.Set<RuvEpisode>()
+            .ToListAsync(cancellationToken);
+        episodes.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenRuvClientThrowsForFirstProgram_FirstIsMarkedComplete_SecondStillProcesses()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        using (RuvarrDbContext seedContext = CreateDbContext())
+        {
+            await seedContext.Database.EnsureCreatedAsync(cancellationToken);
+
+            RuvProgram program1 = new RuvProgramBuilder()
+                .WithRuvId(Program1RuvId)
+                .WithName(Program1Name)
+                .WithMultipleEpisodes()
+                .Build();
+
+            RuvProgram program2 = new RuvProgramBuilder()
+                .WithRuvId(Program2RuvId)
+                .WithName(Program2Name)
+                .WithMultipleEpisodes()
+                .Build();
+
+            seedContext.Set<RuvProgram>().Add(program1);
+            seedContext.Set<RuvProgram>().Add(program2);
+            await seedContext.SaveChangesAsync(cancellationToken);
+        }
+
+        _ruv.GetProgramAsync(Program1RuvId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("RÚV unavailable"));
+
+        RuvTvEpisode episode2 = CreateRuvTvEpisode(Program2EpisodeId, title: "Episode 1");
+        RuvTvProgram apiResponse2 = CreateRuvTvProgram(Program2RuvId, Program2Name, episodes: [episode2]);
+        _ruv.GetProgramAsync(Program2RuvId, Arg.Any<CancellationToken>())
+            .Returns(apiResponse2);
+
+        _syncQueue.Enqueue(Program1RuvId, Program1Name);
+        _syncQueue.Enqueue(Program2RuvId, Program2Name);
+
+        using RuvarrDbContext actContext = CreateDbContext();
+        RuvEpisodesSyncJob sut = CreateJob(actContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert — no item stuck in Processing; queue fully drained
+        _syncQueue.Items.ShouldBeEmpty();
+
+        // Assert — program2's episode was persisted
+        using RuvarrDbContext assertContext = CreateDbContext();
+        List<RuvEpisode> episodes = await assertContext.Set<RuvEpisode>()
+            .ToListAsync(cancellationToken);
+        episodes.ShouldContain(e => e.RuvId == Program2EpisodeId);
+    }
+
+    [Fact]
+    public async Task WhenSaveChangesFailsForFirstProgram_ChangeTrackerIsCleared_SecondProgramSavesItsOwnChangesOnly()
+    {
+        // Arrange
+        // Seed program1 with one existing episode. The RÚV API will return a new episode for
+        // program1 whose RuvId conflicts with a row we raw-insert into the DB after seeding.
+        // That causes SaveChanges to fail with a unique constraint violation. The per-program
+        // catch block must call ChangeTracker.Clear() before continuing, otherwise program1's
+        // pending-insert state carries over into program2's SaveChanges and causes a second failure.
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        using (RuvarrDbContext seedContext = CreateDbContext())
+        {
+            await seedContext.Database.EnsureCreatedAsync(cancellationToken);
+
+            RuvProgram program1 = new RuvProgramBuilder()
+                .WithRuvId(Program1RuvId)
+                .WithName(Program1Name)
+                .WithMultipleEpisodes()
+                .Build();
+
+            RuvProgram program2 = new RuvProgramBuilder()
+                .WithRuvId(Program2RuvId)
+                .WithName(Program2Name)
+                .WithMultipleEpisodes()
+                .Build();
+
+            seedContext.Set<RuvProgram>().Add(program1);
+            seedContext.Set<RuvProgram>().Add(program2);
+            await seedContext.SaveChangesAsync(cancellationToken);
+
+            // Raw-insert an episode with ConflictingEpisodeId against program1's surrogate key.
+            // When the job tries to add an episode with the same RuvId, SaveChanges will fail
+            // with a UNIQUE constraint violation on the episodes.ruv_id index.
+            await seedContext.Database.ExecuteSqlAsync(
+                $"""
+                INSERT INTO episodes (ruv_id, uri, title, description, first_run, duration_seconds, lookup_count, program_id)
+                SELECT {ConflictingEpisodeId}, 'http://ruv.is/conflict', 'Conflicting Episode', 'desc', datetime('now'), 1800, 0, id
+                FROM programs WHERE ruv_id = {Program1RuvId}
+                """,
+                cancellationToken);
+        }
+
+        // The RÚV API returns an episode with ConflictingEpisodeId for program1 — this will
+        // try to add a duplicate, causing SaveChanges to fail on the unique RuvId index.
+        RuvTvEpisode conflictEpisode = CreateRuvTvEpisode(ConflictingEpisodeId, title: "Conflict Episode");
+        RuvTvProgram apiResponse1 = CreateRuvTvProgram(Program1RuvId, Program1Name, episodes: [conflictEpisode]);
+        _ruv.GetProgramAsync(Program1RuvId, Arg.Any<CancellationToken>())
+            .Returns(apiResponse1);
+
+        RuvTvEpisode episode2 = CreateRuvTvEpisode(Program2EpisodeId, title: "Episode 1");
+        RuvTvProgram apiResponse2 = CreateRuvTvProgram(Program2RuvId, Program2Name, episodes: [episode2]);
+        _ruv.GetProgramAsync(Program2RuvId, Arg.Any<CancellationToken>())
+            .Returns(apiResponse2);
+
+        _syncQueue.Enqueue(Program1RuvId, Program1Name);
+        _syncQueue.Enqueue(Program2RuvId, Program2Name);
+
+        // Use ONE shared dbContext across both iterations — same as what the job does
+        using RuvarrDbContext actContext = CreateDbContext();
+        RuvEpisodesSyncJob sut = CreateJob(actContext);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert — no item stuck in Processing
+        _syncQueue.Items.ShouldBeEmpty();
+
+        // Assert — program2's episode is persisted (ChangeTracker.Clear() allowed program2 to save cleanly)
+        using RuvarrDbContext assertContext = CreateDbContext();
+        List<RuvEpisode> episodes = await assertContext.Set<RuvEpisode>()
+            .ToListAsync(cancellationToken);
+        episodes.ShouldContain(e => e.RuvId == Program2EpisodeId,
+            "program2's episode should be saved; ChangeTracker.Clear() must have isolated program1's failure");
+    }
+
+    private static RuvTvEpisode CreateRuvTvEpisode(string id, string? title) => new(
+        Id: id,
+        Number: 1,
+        SeriesId: Program2RuvId,
+        FirstRun: DateTime.UtcNow,
+        FileExpires: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)),
+        Rating: 0,
+        Duration: 1800,
+        DurationFriendly: "30 min",
+        Event: 0,
+        Title: title,
+        Slug: "test-episode",
+        Description: ["Test description"],
+        ImageRenditions: new RuvImageRenditions([]),
+        Image: new Uri("http://ruv.is/image.jpg"),
+        ImageOg: new Uri("http://ruv.is/image-og.jpg"),
+        Scope: "ruv",
+        SubtitlesUrl: new Uri("http://ruv.is/subs.vtt"),
+        Subtitles: new RuvSubtitles(new Uri("http://ruv.is/subs-is.vtt")),
+        OpenSubtitles: false,
+        ClosedSubtitles: false,
+        AutoSubtitles: false,
+        File: new Uri("http://ruv.is/stream.m3u8"),
+        Temp: new RuvTemp("file.mp4", "folder"),
+        Clips: [],
+        Files: new RuvFiles(new RuvVodmp4("file.mp4", "folder", "file", false, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)), 0, "0", "mp4", "ruv")),
+        CreditPoint: 0);
+
+    private static RuvTvProgram CreateRuvTvProgram(int id, string name, IReadOnlyList<RuvTvEpisode> episodes) => new(
+        LastUpdated: DateTimeOffset.UtcNow,
+        Id: id,
+        Title: name,
+        ForeignTitle: "Test",
+        Slug: "test-program",
+        ImageRenditions: new RuvImageRenditions([]),
+        Image: null,
+        ImageOg: new Uri("http://ruv.is/og.jpg"),
+        PortraitImageRenditions: new RuvPortraitImageRenditions([]),
+        PortraitImage: new Uri("http://ruv.is/portrait.jpg"),
+        Description: ["Test description"],
+        Format: "tv",
+        Categories: [],
+        Division: "test",
+        MultipleEpisodes: true,
+        Episodes: episodes,
+        ReverseEpisodeOrder: false,
+        WebAvailableEpisodes: episodes.Count,
+        VodAvailableEpisodes: episodes.Count,
+        PodcastVailableEpisodes: 0,
+        WebLatestDate: DateTime.UtcNow,
+        Channel: "ruv",
+        WebPlayerUrl: new Uri("http://ruv.is/player"));
+}

--- a/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/PerProgramIsolation.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/PerProgramIsolation.cs
@@ -161,11 +161,12 @@ public sealed class PerProgramIsolation
     public async Task WhenSaveChangesFailsForFirstProgram_ChangeTrackerIsCleared_SecondProgramSavesItsOwnChangesOnly()
     {
         // Arrange
-        // Seed program1 with one existing episode. The RÚV API will return a new episode for
-        // program1 whose RuvId conflicts with a row we raw-insert into the DB after seeding.
-        // That causes SaveChanges to fail with a unique constraint violation. The per-program
-        // catch block must call ChangeTracker.Clear() before continuing, otherwise program1's
-        // pending-insert state carries over into program2's SaveChanges and causes a second failure.
+        // Program1 is seeded with no episodes so FindRuvProgramAsync loads an empty _episodes list.
+        // When the RÚV client is called for program1, a side-effect inserts a conflicting row into
+        // the DB via a separate context. TryAddEpisode therefore succeeds (no in-memory duplicate),
+        // but the subsequent SaveChangesAsync violates the unique index on episodes.ruv_id and throws.
+        // The per-program catch block must call ChangeTracker.Clear() before continuing; without it,
+        // program1's pending-insert state would carry over into program2's SaveChanges and fail that too.
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
 
         using (RuvarrDbContext seedContext = CreateDbContext())
@@ -187,25 +188,26 @@ public sealed class PerProgramIsolation
             seedContext.Set<RuvProgram>().Add(program1);
             seedContext.Set<RuvProgram>().Add(program2);
             await seedContext.SaveChangesAsync(cancellationToken);
-
-            // Raw-insert an episode with ConflictingEpisodeId against program1's surrogate key.
-            // When the job tries to add an episode with the same RuvId, SaveChanges will fail
-            // with a UNIQUE constraint violation on the episodes.ruv_id index.
-            await seedContext.Database.ExecuteSqlAsync(
-                $"""
-                INSERT INTO episodes (ruv_id, uri, title, description, first_run, duration_seconds, lookup_count, program_id)
-                SELECT {ConflictingEpisodeId}, 'http://ruv.is/conflict', 'Conflicting Episode', 'desc', datetime('now'), 1800, 0, id
-                FROM programs WHERE ruv_id = {Program1RuvId}
-                """,
-                cancellationToken);
         }
 
-        // The RÚV API returns an episode with ConflictingEpisodeId for program1 — this will
-        // try to add a duplicate, causing SaveChanges to fail on the unique RuvId index.
+        // The RÚV API returns an episode with ConflictingEpisodeId for program1.
+        // As a side-effect of returning the response, insert that same RuvId into the DB
+        // via a separate context so SaveChanges sees a unique-index collision.
         RuvTvEpisode conflictEpisode = CreateRuvTvEpisode(ConflictingEpisodeId, title: "Conflict Episode");
         RuvTvProgram apiResponse1 = CreateRuvTvProgram(Program1RuvId, Program1Name, episodes: [conflictEpisode]);
         _ruv.GetProgramAsync(Program1RuvId, Arg.Any<CancellationToken>())
-            .Returns(apiResponse1);
+            .Returns(async (_) =>
+            {
+                using RuvarrDbContext sideContext = CreateDbContext();
+                await sideContext.Database.ExecuteSqlAsync(
+                    $"""
+                    INSERT INTO episodes (ruv_id, uri, title, description, first_run, duration_seconds, lookup_count, program_id)
+                    SELECT {ConflictingEpisodeId}, 'http://ruv.is/x', 'Conflict', '', datetime('now'), 1800, 0, id
+                    FROM programs WHERE ruv_id = {Program1RuvId}
+                    """,
+                    cancellationToken);
+                return (RuvTvProgram?)apiResponse1;
+            });
 
         RuvTvEpisode episode2 = CreateRuvTvEpisode(Program2EpisodeId, title: "Episode 1");
         RuvTvProgram apiResponse2 = CreateRuvTvProgram(Program2RuvId, Program2Name, episodes: [episode2]);
@@ -222,15 +224,21 @@ public sealed class PerProgramIsolation
         // Act
         await sut.Execute(null!);
 
-        // Assert — no item stuck in Processing
+        // Assert — no item stuck in Processing; queue fully drained
         _syncQueue.Items.ShouldBeEmpty();
 
-        // Assert — program2's episode is persisted (ChangeTracker.Clear() allowed program2 to save cleanly)
+        // Assert — program2's episode is persisted (ChangeTracker.Clear() isolated program1's failure).
+        // ConflictingEpisodeId exists once from the side-effect insert; program1's SaveChanges threw
+        // before it could duplicate it. Without ChangeTracker.Clear(), program1's pending-insert state
+        // would carry over to program2's SaveChanges and prevent ep-p21 from being saved.
         using RuvarrDbContext assertContext = CreateDbContext();
         List<RuvEpisode> episodes = await assertContext.Set<RuvEpisode>()
             .ToListAsync(cancellationToken);
+
+        episodes.Count(e => e.RuvId == ConflictingEpisodeId).ShouldBe(1,
+            "there must be exactly one ep-p1x row (from the side-effect insert); program1's SaveChanges must have thrown");
         episodes.ShouldContain(e => e.RuvId == Program2EpisodeId,
-            "program2's episode should be saved; ChangeTracker.Clear() must have isolated program1's failure");
+            "program2's episode must be saved; ChangeTracker.Clear() must have isolated program1's failure");
     }
 
     private static RuvTvEpisode CreateRuvTvEpisode(string id, string? title) => new(

--- a/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/PerProgramIsolation.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/PerProgramIsolation.cs
@@ -80,7 +80,7 @@ public sealed class PerProgramIsolation
             await seedContext.SaveChangesAsync(cancellationToken);
         }
 
-        RuvTvEpisode titlelessEpisode = CreateRuvTvEpisode(TitlelessEpisodeId, title: null);
+        RuvTvEpisode titlelessEpisode = CreateRuvTvEpisode(GeisliRuvId, TitlelessEpisodeId, title: null);
         RuvTvProgram apiResponse = CreateRuvTvProgram(GeisliRuvId, GeisliName, episodes: [titlelessEpisode]);
 
         _ruv.GetProgramAsync(GeisliRuvId, Arg.Any<CancellationToken>())
@@ -133,7 +133,7 @@ public sealed class PerProgramIsolation
         _ruv.GetProgramAsync(Program1RuvId, Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("RÚV unavailable"));
 
-        RuvTvEpisode episode2 = CreateRuvTvEpisode(Program2EpisodeId, title: "Episode 1");
+        RuvTvEpisode episode2 = CreateRuvTvEpisode(Program2RuvId, Program2EpisodeId, title: "Episode 1");
         RuvTvProgram apiResponse2 = CreateRuvTvProgram(Program2RuvId, Program2Name, episodes: [episode2]);
         _ruv.GetProgramAsync(Program2RuvId, Arg.Any<CancellationToken>())
             .Returns(apiResponse2);
@@ -193,7 +193,7 @@ public sealed class PerProgramIsolation
         // The RÚV API returns an episode with ConflictingEpisodeId for program1.
         // As a side-effect of returning the response, insert that same RuvId into the DB
         // via a separate context so SaveChanges sees a unique-index collision.
-        RuvTvEpisode conflictEpisode = CreateRuvTvEpisode(ConflictingEpisodeId, title: "Conflict Episode");
+        RuvTvEpisode conflictEpisode = CreateRuvTvEpisode(Program1RuvId, ConflictingEpisodeId, title: "Conflict Episode");
         RuvTvProgram apiResponse1 = CreateRuvTvProgram(Program1RuvId, Program1Name, episodes: [conflictEpisode]);
         _ruv.GetProgramAsync(Program1RuvId, Arg.Any<CancellationToken>())
             .Returns(async (_) =>
@@ -209,7 +209,7 @@ public sealed class PerProgramIsolation
                 return (RuvTvProgram?)apiResponse1;
             });
 
-        RuvTvEpisode episode2 = CreateRuvTvEpisode(Program2EpisodeId, title: "Episode 1");
+        RuvTvEpisode episode2 = CreateRuvTvEpisode(Program2RuvId, Program2EpisodeId, title: "Episode 1");
         RuvTvProgram apiResponse2 = CreateRuvTvProgram(Program2RuvId, Program2Name, episodes: [episode2]);
         _ruv.GetProgramAsync(Program2RuvId, Arg.Any<CancellationToken>())
             .Returns(apiResponse2);
@@ -241,10 +241,10 @@ public sealed class PerProgramIsolation
             "program2's episode must be saved; ChangeTracker.Clear() must have isolated program1's failure");
     }
 
-    private static RuvTvEpisode CreateRuvTvEpisode(string id, string? title) => new(
+    private static RuvTvEpisode CreateRuvTvEpisode(int seriesId, string id, string? title) => new(
         Id: id,
         Number: 1,
-        SeriesId: Program2RuvId,
+        SeriesId: seriesId,
         FirstRun: DateTime.UtcNow,
         FileExpires: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)),
         Rating: 0,

--- a/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/TitlelessEpisodeSkip.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/TitlelessEpisodeSkip.cs
@@ -90,7 +90,7 @@ public sealed class TitlelessEpisodeSkip
 
         // Assert
         logger.Entries.ShouldContain(e =>
-            e.LogLevel >= LogLevel.Debug
+            e.LogLevel == LogLevel.Information
             && e.Message.Contains(EpisodeId)
             && e.Message.Contains(ProgramName));
     }

--- a/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/TitlelessEpisodeSkip.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/TitlelessEpisodeSkip.cs
@@ -20,7 +20,7 @@ namespace Ruvarr.UnitTests.Jobs.RuvEpisodesSyncJobTests;
 public sealed class TitlelessEpisodeSkip
 {
     private const int RuvProgramId = 77;
-    private const string EpisodeId = "ep-titleless";
+    private const string EpisodeId = "ep-tls";
     private const string ProgramName = "Test Program";
 
     private readonly IRuvClient _ruv = Substitute.For<IRuvClient>();

--- a/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/TitlelessEpisodeSkip.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/TitlelessEpisodeSkip.cs
@@ -1,0 +1,209 @@
+using Microsoft.EntityFrameworkCore;
+
+using NSubstitute;
+
+using Ruvarr.Abstractions;
+using Ruvarr.Infrastructure.Ruv;
+using Ruvarr.Infrastructure.Ruv.Models;
+using Ruvarr.Infrastructure.Sonarr;
+using Ruvarr.Infrastructure.Sonarr.Models;
+using Ruvarr.Jobs;
+using Ruvarr.ProgramRefreshQueue.Notifiers;
+using Ruvarr.Programs.Domain;
+using Ruvarr.Settings;
+using Ruvarr.Testing.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Jobs.RuvEpisodesSyncJobTests;
+
+public sealed class TitlelessEpisodeSkip
+{
+    private const int RuvProgramId = 77;
+    private const string EpisodeId = "ep-titleless";
+    private const string ProgramName = "Test Program";
+
+    private readonly IRuvClient _ruv = Substitute.For<IRuvClient>();
+    private readonly ISonarrClient _sonarr = Substitute.For<ISonarrClient>();
+    private readonly ProgramRefreshNotifier _syncQueue = new();
+    private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
+    private readonly ISettingsStore _settingsStore = Substitute.For<ISettingsStore>();
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.db");
+
+    public TitlelessEpisodeSkip()
+    {
+        _serviceProvider.GetService(Arg.Any<Type>()).Returns(Array.Empty<object>());
+        _settingsStore.Current.Returns(new RuvarrSettings(
+            SonarrBaseAddress: "http://sonarr", SonarrApiKey: "key"));
+        _sonarr.GetSeriesAsync(Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Series>());
+        _sonarr.GetMissingEpisodesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MissingEpisode>());
+    }
+
+    private RuvarrDbContext CreateDbContext() => new(
+        new DbContextOptionsBuilder<RuvarrDbContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .UseSnakeCaseNamingConvention()
+            .Options,
+        _serviceProvider);
+
+    private RuvEpisodesSyncJob CreateJob(RuvarrDbContext dbContext, ILogger<RuvEpisodesSyncJob> logger) => new(
+        logger,
+        _ruv, dbContext, _sonarr, _syncQueue, new DomainEventBroadcaster(), _settingsStore);
+
+    [Fact]
+    public async Task WhenEpisodeTitleIsNull_LogsSkipAtInformation()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        using (RuvarrDbContext seedContext = CreateDbContext())
+        {
+            await seedContext.Database.EnsureCreatedAsync(cancellationToken);
+
+            RuvProgram program = new RuvProgramBuilder()
+                .WithRuvId(RuvProgramId)
+                .WithName(ProgramName)
+                .WithMultipleEpisodes()
+                .Build();
+
+            seedContext.Set<RuvProgram>().Add(program);
+            await seedContext.SaveChangesAsync(cancellationToken);
+        }
+
+        RuvTvEpisode titlelessEpisode = CreateRuvTvEpisode(EpisodeId, title: null);
+        RuvTvProgram apiResponse = CreateRuvTvProgram(RuvProgramId, episodes: [titlelessEpisode]);
+
+        _ruv.GetProgramAsync(RuvProgramId, Arg.Any<CancellationToken>())
+            .Returns(apiResponse);
+
+        _syncQueue.Enqueue(RuvProgramId, ProgramName);
+
+        CapturingLogger<RuvEpisodesSyncJob> logger = new();
+
+        using RuvarrDbContext actContext = CreateDbContext();
+        RuvEpisodesSyncJob sut = CreateJob(actContext, logger);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        logger.Entries.ShouldContain(e =>
+            e.LogLevel >= LogLevel.Debug
+            && e.Message.Contains(EpisodeId)
+            && e.Message.Contains(ProgramName));
+    }
+
+    [Fact]
+    public async Task WhenEpisodeTitleIsNull_DoesNotPersistEpisode()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        using (RuvarrDbContext seedContext = CreateDbContext())
+        {
+            await seedContext.Database.EnsureCreatedAsync(cancellationToken);
+
+            RuvProgram program = new RuvProgramBuilder()
+                .WithRuvId(RuvProgramId)
+                .WithName(ProgramName)
+                .WithMultipleEpisodes()
+                .Build();
+
+            seedContext.Set<RuvProgram>().Add(program);
+            await seedContext.SaveChangesAsync(cancellationToken);
+        }
+
+        RuvTvEpisode titlelessEpisode = CreateRuvTvEpisode(EpisodeId, title: null);
+        RuvTvProgram apiResponse = CreateRuvTvProgram(RuvProgramId, episodes: [titlelessEpisode]);
+
+        _ruv.GetProgramAsync(RuvProgramId, Arg.Any<CancellationToken>())
+            .Returns(apiResponse);
+
+        _syncQueue.Enqueue(RuvProgramId, ProgramName);
+
+        using RuvarrDbContext actContext = CreateDbContext();
+        RuvEpisodesSyncJob sut = CreateJob(actContext, new CapturingLogger<RuvEpisodesSyncJob>());
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        using RuvarrDbContext assertContext = CreateDbContext();
+        List<RuvEpisode> episodes = await assertContext.Set<RuvEpisode>().ToListAsync(cancellationToken);
+        episodes.ShouldBeEmpty();
+    }
+
+    private static RuvTvEpisode CreateRuvTvEpisode(string id, string? title) => new(
+        Id: id,
+        Number: 1,
+        SeriesId: RuvProgramId,
+        FirstRun: DateTime.UtcNow,
+        FileExpires: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)),
+        Rating: 0,
+        Duration: 1800,
+        DurationFriendly: "30 min",
+        Event: 0,
+        Title: title,
+        Slug: "titleless-episode",
+        Description: ["No title here"],
+        ImageRenditions: new RuvImageRenditions([]),
+        Image: new Uri("http://ruv.is/image.jpg"),
+        ImageOg: new Uri("http://ruv.is/image-og.jpg"),
+        Scope: "ruv",
+        SubtitlesUrl: new Uri("http://ruv.is/subs.vtt"),
+        Subtitles: new RuvSubtitles(new Uri("http://ruv.is/subs-is.vtt")),
+        OpenSubtitles: false,
+        ClosedSubtitles: false,
+        AutoSubtitles: false,
+        File: new Uri("http://ruv.is/stream.m3u8"),
+        Temp: new RuvTemp("file.mp4", "folder"),
+        Clips: [],
+        Files: new RuvFiles(new RuvVodmp4("file.mp4", "folder", "file", false, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)), 0, "0", "mp4", "ruv")),
+        CreditPoint: 0);
+
+    private static RuvTvProgram CreateRuvTvProgram(int id, IReadOnlyList<RuvTvEpisode> episodes) => new(
+        LastUpdated: DateTimeOffset.UtcNow,
+        Id: id,
+        Title: ProgramName,
+        ForeignTitle: "Test",
+        Slug: "test-program",
+        ImageRenditions: new RuvImageRenditions([]),
+        Image: null,
+        ImageOg: new Uri("http://ruv.is/og.jpg"),
+        PortraitImageRenditions: new RuvPortraitImageRenditions([]),
+        PortraitImage: new Uri("http://ruv.is/portrait.jpg"),
+        Description: ["Test description"],
+        Format: "tv",
+        Categories: [],
+        Division: "test",
+        MultipleEpisodes: true,
+        Episodes: episodes,
+        ReverseEpisodeOrder: false,
+        WebAvailableEpisodes: episodes.Count,
+        VodAvailableEpisodes: episodes.Count,
+        PodcastVailableEpisodes: 0,
+        WebLatestDate: DateTime.UtcNow,
+        Channel: "ruv",
+        WebPlayerUrl: new Uri("http://ruv.is/player"));
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel LogLevel, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+}

--- a/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/TitlelessEpisodeSkip.cs
+++ b/tests/Ruvarr.UnitTests/Jobs/RuvEpisodesSyncJobTests/TitlelessEpisodeSkip.cs
@@ -53,6 +53,52 @@ public sealed class TitlelessEpisodeSkip
         _ruv, dbContext, _sonarr, _syncQueue, new DomainEventBroadcaster(), _settingsStore);
 
     [Fact]
+    public async Task WhenEpisodeTitleContainsNewline_LoggedTitleHasNewlineStripped()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        using (RuvarrDbContext seedContext = CreateDbContext())
+        {
+            await seedContext.Database.EnsureCreatedAsync(cancellationToken);
+
+            RuvProgram program = new RuvProgramBuilder()
+                .WithRuvId(RuvProgramId)
+                .WithName(ProgramName)
+                .WithMultipleEpisodes()
+                .Build();
+
+            seedContext.Set<RuvProgram>().Add(program);
+            await seedContext.SaveChangesAsync(cancellationToken);
+        }
+
+        RuvTvEpisode episodeWithNewlineTitle = CreateRuvTvEpisode("ep-lf", title: "Title\nFake log line");
+        RuvTvProgram apiResponse = CreateRuvTvProgram(RuvProgramId, episodes: [episodeWithNewlineTitle]);
+
+        _ruv.GetProgramAsync(RuvProgramId, Arg.Any<CancellationToken>())
+            .Returns(apiResponse);
+
+        _syncQueue.Enqueue(RuvProgramId, ProgramName);
+
+        CapturingLogger<RuvEpisodesSyncJob> logger = new();
+
+        using RuvarrDbContext actContext = CreateDbContext();
+        RuvEpisodesSyncJob sut = CreateJob(actContext, logger);
+
+        // Act
+        await sut.Execute(null!);
+
+        // Assert
+        logger.Entries.ShouldContain(e =>
+            e.LogLevel == LogLevel.Information
+            && e.Message.Contains("Added RÚV episode"),
+            "the added-episode log entry must exist");
+
+        logger.Entries.ShouldAllBe(e => !e.Message.Contains('\n'),
+            "no log entry should contain an embedded newline from externally-sourced data");
+    }
+
+    [Fact]
     public async Task WhenEpisodeTitleIsNull_LogsSkipAtInformation()
     {
         // Arrange

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramDbContextExtensionsTests/FindRuvProgramAsync.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramDbContextExtensionsTests/FindRuvProgramAsync.cs
@@ -1,0 +1,115 @@
+using Microsoft.EntityFrameworkCore;
+
+using NSubstitute;
+
+using Ruvarr.Programs.Domain;
+using Ruvarr.Testing.Builders;
+
+using Shouldly;
+
+namespace Ruvarr.UnitTests.Programs.Domain.RuvProgramDbContextExtensionsTests;
+
+public sealed class FindRuvProgramAsync
+{
+    private const int ExistingRuvId = 42;
+
+    private readonly IServiceProvider _serviceProvider = Substitute.For<IServiceProvider>();
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.db");
+
+    public FindRuvProgramAsync()
+    {
+        _serviceProvider.GetService(Arg.Any<Type>()).Returns(Array.Empty<object>());
+    }
+
+    private RuvarrDbContext CreateDbContext() => new(
+        new DbContextOptionsBuilder<RuvarrDbContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .UseSnakeCaseNamingConvention()
+            .Options,
+        _serviceProvider);
+
+    [Fact]
+    public async Task WhenProgramExists_ReturnsProgramWithEpisodesAndTvdbEpisodes()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        using (RuvarrDbContext seedContext = CreateDbContext())
+        {
+            await seedContext.Database.EnsureCreatedAsync(cancellationToken);
+
+            RuvProgram program = new RuvProgramBuilder()
+                .WithRuvId(ExistingRuvId)
+                .WithMultipleEpisodes()
+                .Build();
+
+            program.TryAddEpisode(
+                id: "ep-1",
+                uri: new Uri("http://ruv.is/ep1"),
+                title: "Episode 1",
+                description: "First",
+                firstRun: DateTime.UtcNow,
+                duration: TimeSpan.FromMinutes(30));
+
+            seedContext.Set<RuvProgram>().Add(program);
+            await seedContext.SaveChangesAsync(cancellationToken);
+        }
+
+        // Act
+        using RuvarrDbContext actContext = CreateDbContext();
+        RuvProgram? result = await actContext.FindRuvProgramAsync(ExistingRuvId, cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.RuvId.ShouldBe(ExistingRuvId);
+        result.Episodes.Count.ShouldBe(1);
+        result.Episodes[0].TvdbEpisodes.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task WhenProgramMissing_ReturnsNull()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        using (RuvarrDbContext seedContext = CreateDbContext())
+        {
+            await seedContext.Database.EnsureCreatedAsync(cancellationToken);
+        }
+
+        // Act
+        using RuvarrDbContext actContext = CreateDbContext();
+        RuvProgram? result = await actContext.FindRuvProgramAsync(ExistingRuvId, cancellationToken);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task WhenProgramExists_IsTracked()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        using (RuvarrDbContext seedContext = CreateDbContext())
+        {
+            await seedContext.Database.EnsureCreatedAsync(cancellationToken);
+
+            RuvProgram program = new RuvProgramBuilder()
+                .WithRuvId(ExistingRuvId)
+                .WithMultipleEpisodes()
+                .Build();
+
+            seedContext.Set<RuvProgram>().Add(program);
+            await seedContext.SaveChangesAsync(cancellationToken);
+        }
+
+        // Act
+        using RuvarrDbContext actContext = CreateDbContext();
+        RuvProgram? result = await actContext.FindRuvProgramAsync(ExistingRuvId, cancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        actContext.Entry(result).State.ShouldNotBe(Microsoft.EntityFrameworkCore.EntityState.Detached);
+    }
+}

--- a/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/TryAddEpisode.cs
+++ b/tests/Ruvarr.UnitTests/Programs/Domain/RuvProgramTests/TryAddEpisode.cs
@@ -99,4 +99,71 @@ public sealed class TryAddEpisode
         // Assert
         sut.DomainEvents.ShouldNotContain(e => e is EpisodeAddedToMatchedProgramEvent);
     }
+
+    [Fact]
+    public void WhenTitleIsNull_ReturnsFalse()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+
+        // Act
+        bool result = sut.TryAddEpisode("ep1", new Uri("http://test.com"), null, "Desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void WhenTitleIsNull_DoesNotAddEpisode()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+
+        // Act
+        sut.TryAddEpisode("ep1", new Uri("http://test.com"), null, "Desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+
+        // Assert
+        sut.Episodes.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void WhenTitleIsWhitespace_ReturnsFalse()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+
+        // Act
+        bool result = sut.TryAddEpisode("ep1", new Uri("http://test.com"), "   ", "Desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void WhenTitleIsWhitespace_DoesNotAddEpisode()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+
+        // Act
+        sut.TryAddEpisode("ep1", new Uri("http://test.com"), "   ", "Desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+
+        // Assert
+        sut.Episodes.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void WhenTitleIsBlankAndSeriesIsMatched_DoesNotRaiseEpisodeAddedToMatchedProgramEvent()
+    {
+        // Arrange
+        RuvProgram sut = new RuvProgramBuilder().Build();
+        sut.MatchTvdb(TvdbSeries.Create(1, "Test Series"));
+        sut.ClearDomainEvents();
+
+        // Act
+        sut.TryAddEpisode("ep1", new Uri("http://test.com"), null, "Desc", DateTime.UtcNow, TimeSpan.FromMinutes(30));
+
+        // Assert
+        sut.DomainEvents.ShouldNotContain(e => e is EpisodeAddedToMatchedProgramEvent);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where RÚV episodes published with `title: null` (e.g. Geisli, RÚV id `33205`) crashed the episode sync job and wedged the program refresh queue in **Processing** forever.

`RuvTvEpisode.Title` bound the JSON null into a non-nullable `string`, flowed through `RuvProgram.TryAddEpisode` into the required `RuvEpisode.Title`, and tripped `NOT NULL constraint failed: episodes.title` on `SaveChanges`. The unhandled exception aborted the entire batch, leaving the in-progress item stuck and abandoning the rest — and it survived restarts because the bad data was re-fetched each cycle.

The fix addresses both the **cause** (stop the bad data reaching the DB) and the **symptom** (no single program can stick the queue or abort the batch).

## Changes

- **Domain guard** — `RuvProgram.TryAddEpisode` now returns `false` for null/blank titles (mirrors the existing duplicate guard), so the aggregate never constructs a titleless `RuvEpisode`.
- **Boundary type** — `RuvTvEpisode.Title` is now `string?`, modelling that RÚV can send null. Verified single consumer; no CS8602 sweep needed.
- **Skip logging** — titleless episodes are logged at Information with program name + RÚV episode id, gated on `IsNullOrWhiteSpace` so benign duplicate-skips aren't mislogged.
- **Per-program units of work** — `RuvEpisodesSyncJob` restructured from one up-front batch graph to a lightweight `(RuvId, Name)` projection (sorted Icelandic before the loop) with each program loaded fresh via the new `FindRuvProgramAsync` extension (explicit `.ThenInclude(TvdbEpisodes)` since it lacks `AutoInclude`).
- **Fault isolation** — each program is wrapped in try/catch: on failure (RÚV HTTP or `SaveChanges`) it logs, calls `ChangeTracker.Clear()`, `MarkComplete`, publishes `QueueChangedEvent`, and continues — so one program's failure never cascades into another's save or leaves an item stuck.
- **Security hardening** (from review) — CR/LF stripped from externally-sourced RÚV strings before logging; both catch-all guards exempt `OperationCanceledException` so scheduler shutdown isn't swallowed.
- **ADR 0001** documents the per-program unit-of-work trade-off.

## Test plan

- [x] `TryAddEpisode` guard: null / whitespace / blank-no-event, valid-title regression
- [x] Skip-log fires at Information for titleless episodes (and not for duplicates)
- [x] `FindRuvProgramAsync`: loads episodes + TvdbEpisodes, returns null when missing
- [x] Geisli (single titleless episode) refreshes cleanly with zero episodes (Sqlite context)
- [x] RÚV HTTP throw on first program → marked complete, second still processes, queue empties
- [x] `SaveChanges` failure → `ChangeTracker.Clear()` recovery, no cascade into the next program's save (verified the test fails without the clear)
- [x] 892 unit tests green; build clean under `TreatWarningsAsErrors`

> Note: one pre-existing integration-test flake (`SaveSettingsHandlerTests.CascadeDeletesDownloadQueueItemsForDeletedPrograms`) fails only under parallel runs and reproduces on `main` — unrelated to this branch (the IntegrationTests project is untouched here).

Closes #364
